### PR TITLE
DOC: Updated old array package names + broken links via linkcheck

### DIFF
--- a/NA-overview.rst
+++ b/NA-overview.rst
@@ -1,7 +1,7 @@
 .. note::
  This page contains the missing data document discussed on the mailing
  list -
- http://mail.scipy.org/pipermail/numpy-discussion/2012-May/062206.html
+ https://mail.scipy.org/pipermail/numpy-discussion/2012-May/062206.html
 
 Missing data: an orientation
 ############################
@@ -267,7 +267,7 @@ through this code is that it also mostly uses the .data and .mask
 attributes in preference to performing operations on the MaskedArray
 directly.
   
-__ http://mail.scipy.org/pipermail/numpy-discussion/2012-April/061743.html
+__ https://mail.scipy.org/pipermail/numpy-discussion/2012-April/061743.html
 
 So, these examples make it clear that there is demand for a convenient
 way to keep a data array and a mask array (or even a floating point
@@ -367,7 +367,7 @@ use case, and to also implement a totally independent API for masked
 arrays with ignore semantics and all mask manipulation done explicitly
 through a .mask attribute.
 
-.. _alterNEP: https://gist.github.com/1056379
+.. _alterNEP: https://gist.github.com/njsmith/1056379
 
 Another option would be to define a minimalist aligned array container
 that holds multiple arrays and that can be used to pass them around
@@ -709,11 +709,11 @@ https://github.com/numpy/numpy/blob/master/doc/neps/missing-data.rst
 The alterNEP was Nathaniel's initial attempt at separating MISSING and
 IGNORED handling into bit-patterns versus masks, though there's a
 bunch he would change about the proposal at this point:
-https://gist.github.com/1056379
+https://gist.github.com/njsmith/1056379
 
 miniNEP 2 was a later attempt by Nathaniel to sketch out an
 implementation strategy for NA dtypes:
-https://gist.github.com/1068264
+https://gist.github.com/njsmith/1068264
 
 A discussion overview page is here:
 https://github.com/njsmith/numpy/wiki/NA-discussion-status

--- a/index.rst
+++ b/index.rst
@@ -28,20 +28,20 @@ Getting Started
 ---------------
 
 - `Getting Numpy <http://www.scipy.org/scipylib/download.html>`__
-- `Installing the SciPy Stack <http://www.scipy.org/Installing_SciPy>`__
+- `Installing the SciPy Stack <http://www.scipy.org/install.html>`__
 - `NumPy and SciPy documentation page <http://docs.scipy.org/doc/>`__
-- `NumPy Tutorial <http://www.scipy.org/Tentative_NumPy_Tutorial>`__
-- `NumPy for MATLAB© Users <http://www.scipy.org/NumPy_for_Matlab_Users>`__
-- `NumPy functions by category <http://www.scipy.org/Numpy_Functions_by_Category>`__
-- `NumPy Mailing List <http://www.scipy.org/Mailing_Lists>`__
+- `NumPy Tutorial <https://docs.scipy.org/doc/numpy-dev/user/quickstart.html>`__
+- `NumPy for MATLAB© Users <https://docs.scipy.org/doc/numpy-dev/user/numpy-for-matlab-users.html>`__
+- `NumPy functions by category <https://docs.scipy.org/doc/numpy/reference/routines.html>`__
+- `NumPy Mailing List <http://www.scipy.org/scipylib/mailing-lists.html>`__
 
 
 More Information
 ----------------
 
-- `NumPy Sourceforge Home Page <http://sourceforge.net/projects/numpy/>`__
+- `NumPy Sourceforge Home Page <https://sourceforge.net/projects/numpy/>`__
 - `SciPy Home Page <http://www.scipy.org/>`__
-- `Interfacing with compiled code <http://www.scipy.org/Topical_Software#head-7153b42ac4ea517c7d99ec4f4453555b2302a1f8>`__
+- `Interfacing with compiled code <http://www.scipy.org/topical-software.html>`__
 - `Older python array packages <old_array_packages.html>`__
 
 .. raw:: html
@@ -49,4 +49,3 @@ More Information
    <div style="padding-top: 40px;text-align:center;">
      <script type="text/javascript" src="http://www.ohloh.net/p/4894/widgets/project_partner_badge.js"></script>
    </div>
-

--- a/old_array_packages.rst
+++ b/old_array_packages.rst
@@ -2,69 +2,32 @@
 Older Array Packages
 ====================
 
-Links to the older array packages for Python are provided here. New users
-should start out with NumPy.
+Below is a very brief history of NumPy and the array packages that were important
+to its development. These older array packages are no longer maintained, and users
+are strongly advised to use NumPy for any array-related purposes or refactor any
+pre-existing code to utilize the NumPy library.
 
-.. Much of the documentation for Numeric and Numarray is applicable to the NumPy
-.. package.  However, there are :ref:`significant feature improvements
-.. <new_features>`.  A complete guide to the new system has been written by the
-.. primary developer, Travis Oliphant. It is now in the public domain.  Other
-.. Documentation is available at `the scipy website <http://www.scipy.org/>`_ and
-.. in the docstrings (which can be extracted using pydoc).
-..
-.. Free Documentation for
-.. Numeric (most of which is still valid) is `here
-.. <http://www.numpy.org/numpydoc/numdoc.htm>`_ or as a `pdf
-.. <http://www.numpy.org/numpy.pdf>`_ file.   Obviously you should replace
-.. references to Numeric in that document with numpy (i.e. instead of "import
-.. Numeric", use "import numpy").
+History of NumPy
+================
 
-Upgrading from historical implementations
-=========================================
+NumPy derives from an old library called Numeric, which was the first array object
+built for Python. It was quite successful and was used in a variety of applications
+before being phased out. NumPy also incorporates features introduced by a library
+called Numarray, which was written after Numeric but before NumPy.
 
-NumPy derives from the old Numeric code base and can be used as a replacement
-for Numeric.   It also adds the features introduced by Numarray and can also be
-used to replace Numarray.
+When NumPy was first written, it wasn't actually called "NumPy". For about 6 months at
+the end of 2005, Numpy was called SciPy Core (not to be confused with the full SciPy
+package which remains a `separate <http://www.scipy.org/>`_ package). However, it was
+decided in January 2006 to go with the historical name of NumPy for the new package.
 
-Numeric users should find the transition relatively easy (although not without
-some effort).  There is a module (numpy.oldnumeric.alter_code1) that can
-make most of the necessary changes to your Python code that used Numeric to work
-with NumPy's Numeric compatibility module.
+SourceForge Links
+=================
 
-Users of numarray can also transition their code using a similar module
-(``numpy.numarray.alter_code1``) and the numpy.numarray compatibility layer.
+If for any reason you want to obtain a copy of the original Numeric and Numarray libraries,
+you can download them from SourceForge using the links below:
 
-C-code written to either package can be easily ported to NumPy using
-"numpy/oldnumeric.h" and "numpy/libnumarray.h" for the Numeric C-API and the
-Numarray C-API respectively.
-
-For about 6 months at the end of 2005, Numpy was called SciPy Core (not to be
-confused with the full SciPy package which remains a `separate
-<http://www.scipy.org/>`_ package), and so you may occasionally see references
-to SciPy Core floating around.  It was, however, decided in January 2006 to go
-with the historical name of NumPy for the new package.
-
-Numeric (version 24.2)
-======================
-
-Numeric was the first array object built for Python.  It has been quite
-successful and is used in a wide variety of settings and applications.
-Maintenance has ceased for Numeric, and users should transisition to NumPy as
-quickly as possible.   There is a module called numpy.oldnumeric.alter_code1 in
-NumPy that can make the transition to NumPy easier (it will automatically
-perform the search-and-replace style changes that need to be made to python
-code that uses Numeric to make it work with NumPy).
-
-`Sourceforge Download Page for Numeric
+`Download Page for Numeric
 <http://sourceforge.net/projects/numpy/files/Old%20Numeric/>`__
 
-Numarray
-========
-
-Numarray is another implementation of an array object for Python written after
-Numeric and before NumPy. Sponsors of numarray have indicated they will be
-moving to NumPy as soon as is feasible for them so that eventually numarray
-will be phased out (probably sometime in 2007).
-
-`Sourceforge Download Page for Numarray
+`Download Page for Numarray
 <http://sourceforge.net/projects/numpy/files/Old%20Numarray/>`__


### PR DESCRIPTION
While closing up bad links on `scipy.org` in <a href="https://github.com/scipy/scipy.org/pull/153">#153</a>, I ran into bad links on `numpy.org` as well.  I guess it's not too surprising since the last commit was made 3 (!) years ago!?