### PR TITLE
ENH: update, don't reinitialize the numpy/numpy.github.com repo

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -18,17 +18,15 @@ help:
 
 clean:
 	-rm -rf _build/*
+	-rm -rf built_doc
 
 upload: html
-	cd _build/html && \
-	    touch .nojekyll && \
-	    echo www.numpy.org > CNAME && \
-	    rm -rf .git && \
-	    git init && \
-	    git remote add target git@github.com:numpy/numpy.github.com.git && \
-	    git add -A && \
-	    git commit -m "Rebuild site" -a && \
-	    git push -f target master:master
+	git clone git@github.com:numpy/numpy.github.com built_doc
+	cp -r _build/html/* built_doc
+	git -C built_doc add -A
+	git -C built_doc commit -m "Rebuild site" -a
+	git -C built_doc push origin
+	rm -rf built_doc
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) _build/html

--- a/www/index.rst
+++ b/www/index.rst
@@ -47,14 +47,23 @@ Documentation
 -------------
 
 The most up-to-date NumPy documentation can be found at
-`Latest (development) version <https://www.numpy.org/devdocs>`__.
-It includes a user guide, full reference documentation, a developer guide, meta
-information, and "NumPy Enhancement Proposals" (which include the NumPy Roadmap
-and detailed plans for major new features).
+`Latest (development) version </devdocs>`__.
+It includes a user guide, full reference documentation, a developer guide, and
+meta information. 
 
-A complete archive of documentation for all NumPy releases (minor versions; bug
-fix releases don't contain significant documentation changes) since 2009 can be
-found at https://docs.scipy.org.
+Other links:
+
+- `NumPy Enhancement Proposals <neps>`__ (which include the NumPy Roadmap and detailed
+  plans for major new features).
+- `NumPy verion 1.17 <1.17>`__
+- `NumPy verion 1.16 <1.16>`__
+- `NumPy verion 1.15 <1.15>`__
+- `NumPy verion 1.14 <1.14>`__
+
+.. 
+    A complete archive of documentation for all NumPy releases (minor versions; bug
+    fix releases don't contain significant documentation changes) since 2009 can be
+    found at https://docs.scipy.org.
 
 Support NumPy
 -------------


### PR DESCRIPTION
xref numpy/numpy#13921

Layer this top-level content on top of the existing content, so that we can keep all the content in one repo. Merging this and 13921 means we can deactivate the github pages in numpy/devdocs and numpy/neps.

Since we do not clean out the repo before adding all the generated content, files that are no longer needed will need to be deleted by hand from numpy/numpy.github.com

