### PR TITLE
point doc archive to numpy.org

### DIFF
--- a/www/index.rst
+++ b/www/index.rst
@@ -54,7 +54,9 @@ and detailed plans for major new features).
 
 A complete archive of documentation for all NumPy releases (minor versions; bug
 fix releases don't contain significant documentation changes) since 2009 can be
-found at https://docs.scipy.org.
+found at https://numpy.org/doc/
+
+NumPy Enhancement Proposals (NEPs) can be found at https://numpy.org/neps
 
 Support NumPy
 -------------


### PR DESCRIPTION
As per the new spec, point to numpy.org/doc for archived documents and numpy.org/neps for neps

This still leaves the numpy org with 4 html repos (3 once we fold neps into devdocs) dedicated to github pages.

| Content repo | Trigger | Destination Repo | Web link | Notes |
|---|---|---|---|---|
| numpy.org | Merge to `master` | numpy.github.com | https://numpy.org/ |
| numpy | Merge to `master` | devdocs | https://numpy.org/devdocs |
| numpy | Merge to `master` | neps | https://numpy.org/neps | Can be folded into devdocs |
| numpy | Manual release step | doc | https://numpy.org/doc | Now the canonical home of docu- mentation archive|