### PR TITLE
add link back to main page (instead of scipy.org)

### DIFF
--- a/www/conf.py
+++ b/www/conf.py
@@ -105,7 +105,7 @@ html_theme = 'scipy'
 # documentation.
 html_theme_options = {
     'sidebar': 'right',
-    'rootlinks': [("http://scipy.org/", "Scipy.org")],
+    'rootlinks': [("http://numpy.org/", "NumPy.org")],
     'navigation_links': False,
 }
 


### PR DESCRIPTION
Continuation of #25