### PR TITLE
Ensure CNAME for deployed site is numpy.org, not www.numpy.org

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -22,7 +22,7 @@ clean:
 upload: html
 	cd _build/html && \
 	    touch .nojekyll && \
-	    echo www.numpy.org > CNAME && \
+	    echo numpy.org > CNAME && \
 	    rm -rf .git && \
 	    git init && \
 	    git remote add target git@github.com:numpy/numpy.github.com.git && \


### PR DESCRIPTION
This broke the site 2 days ago, see
https://github.com/numpy/numpy.org/issues/34