### PR TITLE
Update Twitter handle to `numpy_team`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,7 +90,7 @@ languages:
       socialmedia:
       - link: https://github.com/numpy/numpy
         icon: github
-      - link: https://twitter.com/lucperkins
+      - link: https://twitter.com/numpy_team
         icon: twitter
       quicklinks:
         column1:


### PR DESCRIPTION
And we're live: https://twitter.com/numpy_team

No tweets yet, will fix that before we launch the website, as well as set up access for other people and some kind of guideline on what we tweet (Dask just figured that out, we can copy from them).