### PR TITLE
Swap "Learn" and "Array computing" buttons in the top nav bar

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,10 +74,10 @@ languages:
         url: /install
       - title: Documentation
         url: /doc
-      - title: Array computing
-        url: /arraycomputing
       - title: Learn
         url: /learn
+      - title: Array computing
+        url: /arraycomputing
       - title: Community
         url: /community
       - title: About Us

--- a/config.yaml
+++ b/config.yaml
@@ -100,8 +100,8 @@ languages:
               link: /install
             - text: Documentation
               link: /docs
-            - text: Release notes
-              link: /release-notes
+            - text: Learn
+              link: /learn
             - text: Roadmap
               link: /roadmap
         column2:
@@ -109,6 +109,8 @@ languages:
           links:
             - text: About us
               link: /about
+            - text: Community
+              link: /community
             - text: Code of conduct
               link: /code-of-conduct
             - text: Get help


### PR DESCRIPTION
Swapped "Learn" and "Array computing" buttons in the top nav bar to match the approved site map.