### PR TITLE
Remove "general purpose" tab

### DIFF
--- a/layouts/partials/tabs.html
+++ b/layouts/partials/tabs.html
@@ -49,12 +49,6 @@
             </a>
             </li>
 
-            <li>
-            <a href="#tab-trash" class="cd-tabs__item">
-                <svg aria-hidden="true" class="icon icon--xs"><rect x="5" y="7" width="2" height="6"></rect><rect x="9" y="7" width="2" height="6"></rect><path d="M12,1c0-0.6-0.4-1-1-1H5C4.4,0,4,0.4,4,1v2H0v2h1v10c0,0.6,0.4,1,1,1h12c0.6,0,1-0.4,1-1V5h1V3h-4V1z M6,2h4 v1H6V2z M13,5v9H3V5H13z"></path></svg>
-                <span>General Purpose</span>
-            </a>
-            </li>
         </ul> <!-- cd-tabs__list -->
         </nav>
 
@@ -435,12 +429,6 @@
         </tr>
     </table>
   </li>
-
-        <li id="tab-trash" class="cd-tabs__panel text-component">
-            <p>General purpose ... .</p>
-
-            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Minima doloremque optio tenetur, natus voluptatum error vel dolorem atque perspiciatis aliquam nemo id libero dicta est saepe laudantium provident tempore ipsa, accusamus similique laborum, consequatur quia, aut non maiores. Consectetur minus ipsum aliquam pariatur dolorem rerum laudantium minima perferendis in vero voluptatem suscipit cum labore nemo explicabo, itaque nobis debitis molestias officiis? Impedit corporis voluptates reiciendis deleniti, magnam, fuga eveniet! Velit ipsa quo labore molestias mollitia, quidem, alias nisi architecto dolor aliquid qui commodi tempore deleniti animi repellat delectus hic. Alias obcaecati fuga assumenda nihil aliquid sed vero, modi, voluptatem? Vitae voluptas aperiam nostrum quo harum numquam earum facilis sequi. Labore maxime laboriosam omnis delectus odit harum recusandae sint incidunt, totam iure commodi ducimus similique doloremque! Odio quaerat dolorum, alias nihil quam iure delectus repellendus modi cupiditate dolore atque quasi obcaecati quis magni excepturi vel, non nemo consequatur, mollitia rerum amet in. Nesciunt placeat magni, provident tempora possimus ut doloribus ullam!</p>
-        </li>
         </ul> <!-- cd-tabs__panels -->
     </div> <!-- cd-tabs -->
     </div>


### PR DESCRIPTION
I had too much trouble figuring out what should go in that tab,
which is a sign that it probably shouldn't exist.

