### PR TITLE
Fix the link to the new Twitter account

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -60,7 +60,7 @@ A real-time chat room to ask questions about _contributing_ to NumPy.
 
 If you would like to find a local meetup or study group to learn more about NumPy and the wider ecosystem of Python packages for data science and scientific computing, we recommend exploring the [PyData meetups](https://www.meetup.com/pro/pydata/) (150+ meetups, 100,000+ members).
 
-NumPy also organizes in-person sprints for its team and interested contributors occasionally. These are typically planned several months in advance, and will be announced on the [mailing list](https://mail.python.org/mailman/listinfo/numpy-discussion) and on [Twitter](twitter.com/numpy_team).
+NumPy also organizes in-person sprints for its team and interested contributors occasionally. These are typically planned several months in advance, and will be announced on the [mailing list](https://mail.python.org/mailman/listinfo/numpy-discussion) and on [Twitter](https://twitter.com/numpy_team).
 
 
 ## Conferences


### PR DESCRIPTION
Fixing the link to the new Twitter account numpy_team.


