### PR TITLE
Change styling for high-resolution screens

### DIFF
--- a/static/css/section2.css
+++ b/static/css/section2.css
@@ -41,6 +41,14 @@
     }
 }
 
+
+@media only screen and (min-width: 1280px) {
+    .section2-box-content {
+        height: 280px;
+        width: 330px;
+    }
+}
+
 .section2-underline {
     display: inline-block;
     vertical-align: middle;

--- a/static/css/section3.css
+++ b/static/css/section3.css
@@ -81,6 +81,9 @@
     .section3-box-content {
         height: 500px;
     }
+    .section3-box-container {
+        flex-wrap: nowrap;
+    }
 }
 
 .section3-underline {


### PR DESCRIPTION
Fixes gh-168 partially

I changed the positions of key feature and case studies for screen widths larger than 1280px. This example is in 2560 x 1440.
![NumPy - changes](https://user-images.githubusercontent.com/46167686/76998297-39a75800-692b-11ea-8b72-821010107483.png)

@joelachance said that he will re-arrange the NumPy title/CTA & the shell, so they'll be more centered.

If the white space between the the nav bar and key feature section is still there once Joel is done, I'll see if I can remove it.

Let me know of any suggestions or changes.