### PR TITLE
Make "Get started" button link work

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ params:
     # Button text
     buttontext: Get started
     # Where the main hero button links to
-    buttonlink: "#"
+    buttonlink: "/learn"
     # Hero image (from static/images/___)
     image: logos/numpy.svg
   # Customizable navbar. For a dropdown, add a "sublinks" list.

--- a/layouts/partials/hero-body.html
+++ b/layouts/partials/hero-body.html
@@ -18,7 +18,7 @@
                 </div>
                 {{ end }}
                 <div class="hero-cta">
-                    <button class="cta-button">{{ $buttonText }}</button>
+                    <a href="{{ $buttonLink }}"><button class="cta-button">{{ $buttonText }}</button></a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
We have no dedicated "Get started" page. I looked at some other projects, some link to install procedures, some to a quickstart or similar. For now I thought linking to the `Learn` page is most appropriate. That has the (not so great) quickstart guide in the Sphinx docs, an install link, and a bunch of other resources.