### PR TITLE
Fix disappeared blockquotes in case studies.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,10 @@ title: NumPy
 theme: hugo-fresh
 disableKinds: ["taxonomyTerm"]
 DefaultContentLanguage: en
+markup:
+  goldmark:
+    renderer:
+      unsafe: true
 
 params:
   navColor: blue


### PR DESCRIPTION
Hugo 0.60 changes the default for raw html in Markdown files, see https://gohugo.io/news/0.60.0-relnotes/.  This fix follows the recommendation in those release notes.