### PR TITLE
Add content for the lesson displayed when the shell is active.

### DIFF
--- a/layouts/partials/shell-content.html
+++ b/layouts/partials/shell-content.html
@@ -9,5 +9,5 @@
 </div>
 
 <div class="shell-lesson shell-content" style="display: none;">
-    Here we should include a lesson about numpy!
+    {{partial "shell-lesson.html" | print | markdownify}}
 </div>

--- a/layouts/partials/shell-lesson.html
+++ b/layouts/partials/shell-lesson.html
@@ -1,0 +1,26 @@
+
+The standard way to import NumPy:
+
+```python
+>>> import numpy as np
+```
+
+Create a 2-D array, set every second element in some rows, and find max per
+row:
+
+```python
+>>> x = np.arange(15, dtype=np.int64).reshape(3, 5)
+>>> x[1:, ::2] = -99
+>>> x
+array([[  0,   1,   2,   3,   4],
+       [-99,   6, -99,   8, -99],
+       [-99,  11, -99,  13, -99]])
+>>> x.max(axis=1)
+array([ 4,  8, 13])
+```
+
+Generate some random numbers with an exponential distribution:
+```python
+>>> rng = np.random.default_rng()
+>>> samples = rng.exponential(size=2500)
+```

--- a/static/css/shell.css
+++ b/static/css/shell.css
@@ -84,10 +84,18 @@
 
 .shell-lesson {
     display: none;
-    align-items: center;
-    justify-content: center;
-    height: 30%;
-    width: 100%;
+    text-align: left;
+    padding: 15px;
+    height: 100%;
+    width: 60%;
+}
+
+.shell-lesson > p {
+    margin: 2px 0 2px 0;
+}
+
+.highlight:not(:last-child) {
+    margin-bottom: 1px !important;
 }
 
 .demo-caret {


### PR DESCRIPTION
Note that the styling for this needs fixing in `shell.css`, now nothing is visible. I tried with the `shell-content-message` class and got:

![image](https://user-images.githubusercontent.com/98330/77259953-0b0be300-6c85-11ea-8ec7-a3a169bb1b75.png)

So the highlighting is fine, but the text justification is messed up. @joelachance could you help with that?

Closes gh-81

