### PR TITLE
Web accessibility - Contrast ratio for WCGA AA

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,7 +102,6 @@ languages:
             - text: Roadmap
               link: https://numpy.org/neps/roadmap.html
         column2:
-          title: ""
           links:
             - text: About us
               link: /about
@@ -115,7 +114,6 @@ languages:
             - text: Contribute
               link: /contribute
         column3:
-          title: ""
           links:
             - text: Terms of use
               link: /terms

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,7 @@
         <div class="link-column">
           <div class="footer-column">
             <div class="footer-header">
-                <h3>{{ .title }}</h3>
+                <!-- <h3>{{ .title }}</h3> -->
             </div>
             <ul class="link-list">
               {{- range .links }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -12,7 +12,6 @@
         <div class="link-column">
           <div class="footer-column">
             <div class="footer-header">
-                <!-- <h3>{{ .title }}</h3> -->
             </div>
             <ul class="link-list">
               {{- range .links }}

--- a/static/css/section2.css
+++ b/static/css/section2.css
@@ -27,6 +27,10 @@
     font-size: 19px;
 }
 
+.section2-box-text > a {
+    color: #0E73D8;
+}
+
 .section2-box-text {
     margin: 30px 15px;
 }

--- a/static/css/tabs.css
+++ b/static/css/tabs.css
@@ -29,6 +29,7 @@
     text-transform: uppercase;
     letter-spacing: 1.5px;
     font-weight: 500;
+    color: #757575;
 }
 
 #tabs-content > li {


### PR DESCRIPTION
Increased contrast ratio between words and background by changing the color of links in the Key Features, Ecosystem sections and footer.

This meets the contrast ratio a WCGA AA rating. Web Content Accessibility Guidelines and its rating range from A to AAA.

I used WebAIM and WAVE tools to check the rating.

**Questions**
I used ! important in the internal css to override external linked css from UiKit. I know ! important isn't generally recommended but it's how I was able to override the external css. **Does anyone know another way or is using ! important here OK?**

**Can I remove the empty h3 tag in footer.html and empty title in config.yaml?** Or is there a title planned for these sections?
![image](https://user-images.githubusercontent.com/46167686/77450655-f9802380-6dc9-11ea-8e50-aa0eb42163d7.png)
