### PR TITLE
adds list.html to quiet hugo server warning.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,0 +1,1 @@
+<!-- Ignore this file. This quiets a hugo server warning. -->


### PR DESCRIPTION
Quiets this `hugo server` warning: `found no layout file for "HTML" for "section"`