### PR TITLE
Removes underline on nav link hover, updates hover color

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -79,6 +79,11 @@ em {
 
 #navbar-item {
     color: #2e3131;
+    text-decoration: none;
+}
+
+#navbar-item:hover {
+    color: #4DABCF !important;
 }
 
 #feature-card {


### PR DESCRIPTION
Not a ticket, but I like this style for nav rollover a bit better. Previously we had the 'hugo-fresh' orange with underline. This removes the underline and updates the rollover color to the lighter NumPy blue. Open to suggestions!

<img width="211" alt="Screen Shot 2020-03-30 at 7 49 04 AM" src="https://user-images.githubusercontent.com/3891660/77914071-f4542600-725a-11ea-9201-38d5300a96db.png">
