### PR TITLE
Add a News page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,8 @@ params:
   # Customizable navbar. For a dropdown, add a "sublinks" list.
   news:
     title: NumPy v1.18.0
-    content: The C-API for numpy.random defined and documented - Basic infrastructure for linking with 64-bit BLAS and LAPACK - Improved documentation
+    content: A new C-API for numpy.random - Basic infrastructure for linking with 64-bit BLAS and LAPACK
+    url: /news
 
   shell:
     title: placeholder

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,0 +1,52 @@
+---
+title: News
+sidebar: false
+---
+
+
+### Season of Docs acceptance
+
+_May 11, 2020_ -- NumPy got accepted as one of the mentor organizations for
+Google's Season of Docs program. We are excited to again get the opportunity to
+work with a technical writer to improve NumPy's documentation! For more
+details, please see
+[the official Season of Docs site](https://developers.google.com/season-of-docs/) and our
+[ideas page](https://github.com/numpy/numpy/wiki/Google-Season-of-Docs-2020-Project-Ideas).
+
+
+### NumPy 1.18.0 release
+
+_Dec 22, 2019_ -- NumPy 1.18.0 is now available. After the major changes in
+1.17.0, this is a consolidation release. It is the last minor release that will
+support Python 3.5. Highlights of the release includes the addition of basic
+infrastructure for linking with 64-bit BLAS and LAPACK libraries, and a new C-API for ``numpy.random``.
+
+Please see the [release notes](https://github.com/numpy/numpy/releases/tag/v1.18.0) for more details.
+
+
+### NumPy receives a grant from the Chan Zuckerberg Initiative
+
+_Nov 15, 2019_ -- We are very pleased to announce that NumPy and OpenBLAS have received a joint grant for $195,000 from the Chan Zuckerberg Initiative.
+
+This grant is for high-level documentation, website development and graphic design, governance activities and community building for NumPy, and for technical work on OpenBLAS (which is one of NumPy's key dependencies). [This blog post](https://labs.quansight.org/blog/2019/11/numpy-openblas-CZI-grant/) describes what this grant will be about and provides some background on the grant program. The full proposal is published [here](https://figshare.com/articles/Proposal_NumPy_OpenBLAS_for_Chan_Zuckerberg_Initiative_EOSS_2019_round_1/10302167). The program managers wrote a blog post titled [The Invisible Foundations of Biomedicine](https://medium.com/@cziscience/the-invisible-foundations-of-biomedicine-4ab7f8d4f5dd) about the whole program which is also well worth reading.
+
+We're looking forward to what we'll be able to do with this grant. The work is planned to start quite soon, Dec 1st, and run for one year.
+
+
+## Releases
+
+Here is a list of NumPy releases, with links to release notes. All bugfix
+releases (only the `z` changes in the `x.y.z` version number) have no new
+features; minor releases (the `y` increases) do.
+
+- NumPy 1.18.4 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.18.4)) -- _3 May 2020_.
+- NumPy 1.18.3 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.18.3)) -- _19 Apr 2020_.
+- NumPy 1.18.2 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.18.2)) -- _17 Mar 2020_.
+- NumPy 1.18.1 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.18.1)) -- _6 Jan 2020_.
+- NumPy 1.17.5 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.17.5)) -- _1 Jan 2020_.
+- NumPy 1.18.0 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.18.0)) -- _22 Dec 2019_.
+- NumPy 1.17.4 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.17.4)) -- _11 Nov 2019_.
+- NumPy 1.17.0 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.17.0)) -- _26 Jul 2019_.
+- NumPy 1.16.0 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.16.0)) -- _14 Jan 2019_.
+- NumPy 1.15.0 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.15.0)) -- _23 Jul 2018_.
+- NumPy 1.14.0 ([release notes](https://github.com/numpy/numpy/releases/tag/v1.14.0)) -- _7 Jan 2018_.

--- a/layouts/partials/news.html
+++ b/layouts/partials/news.html
@@ -1,8 +1,9 @@
 {{- $news       := .Site.Params.news }}
 {{- $title      := index $news "title" }}
 {{- $content      := index $news "content" }}
+{{- $url      := index $news "url" }}
 
 <div class="news-container">
-    <div class="news-title">{{ $title }}</div>
-    <div class="news-content">{{ $content }}</div>
+    <div class="news-title"> <a href="{{ $url}}"> {{ $title }} </a></div>
+    <div class="news-content"> <a href="{{ $url}}"> {{ $content }} </a></div>
 </div>

--- a/static/css/news.css
+++ b/static/css/news.css
@@ -9,6 +9,14 @@
     white-space: nowrap;
 }
 
+.news-container a {
+    color: white;
+}
+
+.news-container a:hover {
+    color: white;
+}
+
 .news-title {
     display: flex;
     letter-spacing: 1.5px;


### PR DESCRIPTION
Changes to the news element on the front page:
- Make both title and text link to `/news`
- Tweak the text for v.1.18.0

This is what the news page looks like:

![image](https://user-images.githubusercontent.com/98330/82137914-6ccb7200-981c-11ea-868d-c4d94f4081d0.png)
