### PR TITLE
Hide the "array computing" page in the navbar

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,8 +88,6 @@ languages:
         url: https://numpy.org/doc/
       - title: Learn
         url: /learn
-      - title: Array computing
-        url: /arraycomputing
       - title: Community
         url: /community
       - title: About Us


### PR DESCRIPTION
Leave the content for now - it needs work, but is still valuable. This content is also connected to the "Array libraries" tab on the front page.