### PR TITLE
Slightly increase font size of titles of tabs on front page

### DIFF
--- a/static/css/tabs.css
+++ b/static/css/tabs.css
@@ -32,7 +32,7 @@
 
 .uk-nav > li > a {
     height: 35px;
-    font-size: 11px;
+    font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 1.5px;
     font-weight: 500;


### PR DESCRIPTION
Closes gh-236.

This may help the reader discover the tabs slightly more easily, as suggested in gh-236. I'm not sure of impact on overall styling (e.g. mobile), so I won't self-merge this. 