### PR TITLE
Make "Documentation" link to numpy.org/doc/stable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -84,7 +84,7 @@ languages:
       - title: Install
         url: /install
       - title: Documentation
-        url: https://numpy.org/doc/
+        url: https://numpy.org/doc/stable
       - title: Learn
         url: /learn
       - title: Community
@@ -108,7 +108,7 @@ languages:
             - text: Install
               link: /install
             - text: Documentation
-              link: https://numpy.org/doc/
+              link: https://numpy.org/doc/stable
             - text: Learn
               link: /learn
             - text: Roadmap
@@ -142,7 +142,7 @@ languages:
       - title: Install
         url: /nl/install
       - title: Documentation
-        url: https://numpy.org/doc/
+        url: https://numpy.org/doc/stable
       - title: Array computing
         url: /nl/arraycomputing
       - title: Case Studies

--- a/content/en/learn.md
+++ b/content/en/learn.md
@@ -3,7 +3,7 @@ title: Learn
 sidebar: false
 ---
 
-The official NumPy documentation lives at https://numpy.org/doc.
+The official NumPy documentation lives [here](https://numpy.org/doc/stable).
 
 Below is a curated collection of external resources. To contribute, see the [end of this page](#add-to-this-list).
 ***

--- a/layouts/partials/shell-content.html
+++ b/layouts/partials/shell-content.html
@@ -5,7 +5,7 @@
 
 <div class="shell-wait shell-content" style="display: none;">
     <div class="shell-title">While we wait...</div>
-    <div class="shell-content-message">Don't forget to check out the <a href="https://numpy.org/doc/" target="_blank">docs</a></div>
+    <div class="shell-content-message">Don't forget to check out the <a href="https://numpy.org/doc/stable" target="_blank">docs</a></div>
 </div>
 
 <div class="shell-lesson shell-content" style="display: none;">


### PR DESCRIPTION
The numpy.org/doc is a pretty useless page that we will get rid of in the future. The doc/stable link is new, and will keep pointing to the docs of the latest NumPy release. So let's use that.