### PR TITLE
DOC: Drop unneeded word from Ecosystem->Data Science

### DIFF
--- a/layouts/partials/data-science.html
+++ b/layouts/partials/data-science.html
@@ -46,7 +46,7 @@
         <div>
             <p></p><p>
                 For high data volumes, <a href="https://dask.org">Dask</a> and
-                <a href="https://ray.io/">Ray</a> are designed to scale. Stable production
+                <a href="https://ray.io/">Ray</a> are designed to scale. Stable
                 deployments rely on data versioning (<a href="https://dvc.org">DVC</a>),
                 experiment tracking (<a href="https://mlflow.org">MLFlow</a>), and
                 workflow automation (<a href="https://airflow.apache.org">Airflow</a> and


### PR DESCRIPTION
Minor one-word change, dropping the word "production":

>  Stable production deployments rely on

If we say "deployments" we don't need "production."
