### PR TITLE
Minor tweak between title and text in news bar

### DIFF
--- a/static/css/news.css
+++ b/static/css/news.css
@@ -23,6 +23,7 @@
     font-size: 27px;
     font-weight: bold;
     margin: 10px;
+    margin-right: 20px;
 }
 
 @media only screen and (max-width: 1300px) {


### PR DESCRIPTION
Thanks @InessaPawson for the suggestion. I agree it looks better. 

Before:

![image](https://user-images.githubusercontent.com/98330/82753197-21890480-9dc4-11ea-8ddf-40ae69806d35.png)


After:

![image](https://user-images.githubusercontent.com/98330/82753183-103ff800-9dc4-11ea-9212-9958c73db93e.png)
