### PR TITLE
Make the Get Started button point to the Install page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ params:
     # Button text
     buttontext: Get started
     # Where the main hero button links to
-    buttonlink: "/learn"
+    buttonlink: "/install"
     # Hero image (from static/images/___)
     image: logos/numpy.svg
   # Customizable navbar. For a dropdown, add a "sublinks" list.


### PR DESCRIPTION
Suggestion by @InessaPawson, now that the install page has way more content.

Okay one more. Ref gh-233, `Get Started` button.