### PR TITLE
Add a deploy script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-public/
 resources/
 
 *.swp

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,5 @@
 	url = https://github.com/StefMa/hugo-fresh.git
 [submodule "public"]
 	path = public
-	url = git@github.com:numpy/numpy.github.com.git
+	url = https://github.com/numpy/numpy.github.com.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule "themes/hugo-fresh"]
 	path = themes/hugo-fresh
 	url = https://github.com/StefMa/hugo-fresh.git
+[submodule "public"]
+	path = public
+	url = git@github.com:numpy/numpy.github.com.git
+	branch = master

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# If a command fails then the deploy stops
+set -e
+
+printf "\033[0;32mDeploying updates to GitHub...\033[0m\n"
+
+# Build the project.
+hugo
+
+# Go To Public folder
+cd public
+
+# Add changes to git.
+git add .
+
+# Commit changes.
+msg="rebuilding site $(date)"
+if [ -n "$*" ]; then
+	msg="$*"
+fi
+git commit -m "$msg"
+
+# Push source and build repos.
+git push origin master


### PR DESCRIPTION
This follows the Hugo deploy guide for GitHub Pages, https://gohugo.io/hosting-and-deployment/hosting-on-github/#step-by-step-instructions. It worked, page is live.

This may need some tweaks to deal with cleaning up, and documentation about init'ing the submodule.

I'm also wondering if we should guard a bit better about accidental deploys, e.g. restricting permissions on `numpy.github.com` to a subset of the whole web team.