### PR TITLE
Update the meta description of the site

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ markup:
       unsafe: true
 
 params:
+  description: The fundamental package for scientific computing with Python
   navColor: blue
   navbarlogo:
     image: logos/numpy.svg


### PR DESCRIPTION
This shows up at least in Slack when you simple use the link to the
site, and it didn't look pretty. Maybe this needs another change,
but for now this will do.