### PR TITLE
Add Qiskit to Quantum Computing column in scientific-domains.html

### DIFF
--- a/layouts/partials/scientific-domains.html
+++ b/layouts/partials/scientific-domains.html
@@ -51,7 +51,7 @@
             <td class="center-text"></td>
         </tr>
         <tr>
-            <td class="center-text"></td>
+            <td class="center-text"><a href="https://qiskit.org">Qiskit</a></td>
             <td class="center-text"><a href="https://github.com/mwaskom/seaborn">Seaborn</a></td>
             <td class="center-text"></td>
             <td class="center-text"></td>


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The `Quantum Computing` column in `scientific-domains.html` misses Qiskit, a leader in Quantum Computing software that heavily relies on NumPy.

To support this, here are some numbers comparing the main repository for each of the projects under `Quantum Computing`:

| Repository | Used by  | Watches | Stars | Forks |
| ---------- | ---------- | ---------- | ---------- | ---------- |
| https://github.com/rigetti/pyquil  | 100  | 82 | 1K | 279
| https://github.com/qutip/qutip  | 96 | 72 | 841 | 354 |
| https://github.com/Qiskit/qiskit-terra/ | 158 | 235 | 2.8K | 1.1K |
