### PR TITLE
ecosystem: update URLs to https

### DIFF
--- a/layouts/partials/scientific-domains.html
+++ b/layouts/partials/scientific-domains.html
@@ -41,7 +41,7 @@
             <td class="center-text"><a href="https://www.psychopy.org">PsychoPy</a></td>
         </tr>
         <tr>
-            <td class="center-text"><a href="http://docs.rigetti.com/en/stable/start.html">PyQuil</a></td>
+            <td class="center-text"><a href="https://docs.rigetti.com/en/stable/start.html">PyQuil</a></td>
             <td class="center-text"><a href="https://github.com/statsmodels/statsmodels"> statsmodels</a></td>
             <td class="center-text"><a href="https://pywavelets.readthedocs.io">PyWavelets</a></td>
             <td class="center-text"><a href="https://opencv.org">OpenCV</a></td>
@@ -97,7 +97,7 @@
             <td class="center-text"></td>
             <td class="center-text"></td>
             <td class="center-text"><a href="https://geopandas.org/">GeoPandas</a></td>
-            <td class="center-text"><a href="http://ipython.org">IPython</a></td>
+            <td class="center-text"><a href="https://ipython.org">IPython</a></td>
         </tr>
         <tr>
             <td class="center-text"><a href="https://github.com/openvax/pyensembl">PyEnsembl</a></td>

--- a/layouts/partials/visualization.html
+++ b/layouts/partials/visualization.html
@@ -61,7 +61,7 @@
                 <a href="https://plot.ly">Plotly</a>,
                 <a href="https://altair-viz.github.io">Altair</a>,
                 <a href="https://docs.bokeh.org/en/latest/">Bokeh</a>,
-                <a href="http://holoviz.org">Holoviz</a>,
+                <a href="https://holoviz.org">Holoviz</a>,
                 <a href="http://vispy.org">Vispy</a>, and
                 <a href="https://github.com/napari/napari">Napari</a>,
                 to name a few.


### PR DESCRIPTION
IPython, PyQuil, HoloViz can be accessed over https. QuTiP, scikit-bio, VisPy have invalid certificates.