### PR TITLE
Add news entries on 1.19.0, the new logo and the survey

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,8 +32,8 @@ params:
     image: logos/numpy.svg
   # Customizable navbar. For a dropdown, add a "sublinks" list.
   news:
-    title: NumPy v1.18.0
-    content: A new C-API for numpy.random - Basic infrastructure for linking with 64-bit BLAS and LAPACK
+    title: 1st NumPy survey is live!
+    content: please help us make NumPy better and take the survey by July 17th
     url: /news
 
   shell:

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -4,6 +4,15 @@ sidebar: false
 ---
 
 
+### NumPy 1.19.0 release
+
+_Jun 20, 2020_ -- NumPy 1.19.0 is now available. This is the first release
+without Python 2 support, hence it was a "clean-up release". The minimum
+supported Python version is now Python 3.6. An important new feature is that
+the random number generation infrastructure that was introduced in NumPy 1.17.0
+is now accessible from Cython.
+
+
 ### Season of Docs acceptance
 
 _May 11, 2020_ -- NumPy has been accepted as one of the mentor organizations for

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -4,6 +4,22 @@ sidebar: false
 ---
 
 
+### NumPy has a new logo!
+
+_Jun 24, 2020_ -- NumPy now has a new logo:
+
+<img
+  src="/images/logos/numpy_logo.svg"
+  alt="NumPy logo"
+  title="The new NumPy logo"
+  width=300>
+
+The logo is a modern take on the old one, with a cleaner design and a color
+scheme that matches the new website. Thanks to Isabela Presedo-Floyd for
+designing the new logo, as well as to Travis Vaught for the old logo that
+served us well for 15+ years.
+
+
 ### NumPy 1.19.0 release
 
 _Jun 20, 2020_ -- NumPy 1.19.0 is now available. This is the first release

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -4,6 +4,18 @@ sidebar: false
 ---
 
 
+### The inaugural NumPy survey is live!
+
+_Jul 2, 2020_ -- This survey is meant to guide and set priorities for
+decision-making about the development of NumPy as software and as a community.
+The survey is available in 8 additional languages besides English:
+Bangla, Hindi, Japanese, Mandarin, Portuguese, Russian, Spanish and French.
+The survey will run till July 17th.
+
+Please help us make NumPy better and take the survey
+[here](https://umdsurvey.umd.edu/jfe/form/SV_8bJrXjbhXf7saAl).
+
+
 ### NumPy has a new logo!
 
 _Jun 24, 2020_ -- NumPy now has a new logo:


### PR DESCRIPTION
Add three news entries, put survey on the front page (it's still running for a week):

<img width="754" alt="image" src="https://user-images.githubusercontent.com/98330/87231291-4eb26600-c3b6-11ea-9c7b-45c8aece8d8a.png">
