### PR TITLE
Update crowdin.yml for case studies being in a sub-folder

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,6 +2,13 @@ project_identifier: PROJECT_IDENTIFIER_CROWDIN
 api_key: API_KEY_CROWDIN
 base_path: ./
 preserve_hierarchy: true
-files:
-  - source: /content/en/*.md
-    translation: /content/%two_letters_code%/%original_file_name%
+files: [
+  {
+    "source": "/content/en/*.md",
+    "translation": "/content/%two_letters_code%/%original_file_name%"
+  }
+  {
+    "source": "/content/en/case-studies*.md",
+    "translation": "/content/%two_letters_code%/case-studies/%original_file_name%"
+  }
+]


### PR DESCRIPTION
The case studies weren't showing up in Crowdin, this should fix it.

Format as in https://support.crowdin.com/configuration-file/#writing-a-simple-configuration-file