### PR TITLE
Add correct link to FEniCS in scientific-domains.html

### DIFF
--- a/layouts/partials/scientific-domains.html
+++ b/layouts/partials/scientific-domains.html
@@ -111,7 +111,7 @@
         <tr>
             <td class="lastrow-center-text"></td>
             <td class="lastrow-center-text"></td>
-            <td class="lastrow-center-text"><a href="https://github.com/david-kamensky/tIGAr">FEniCS</a></td>
+            <td class="lastrow-center-text"><a href="https://fenicsproject.org/">FEniCS</a></td>
             <td class="lastrow-center-text"></td>
             <td class="lastrow-center-text"></td>
             <td class="lastrow-center-text"></td>


### PR DESCRIPTION
The Mathematical Analysis column in scientific-domains.html had an incorrect link to FEniCS.
I have fixed that.