### PR TITLE
Add logo and meta tags for twitter_cards

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,8 @@ markup:
 
 params:
   description: Why NumPy? Powerful n-dimensional arrays. Numerical computing tools. Interoperable. Performant. Open source.
+  images:
+  - logos/numpy.svg
   navColor: blue
   navbarlogo:
     image: logos/numpy.svg

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,6 +11,7 @@
       <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}" title="{{ .Language.LanguageName }}" />
       {{ end }}
     {{ end }}
+    {{ template "_internal/twitter_cards.html" . }}
   </head>
   <body>
     <!-- Preloader. Set to true for front-page fade-in animation -->


### PR DESCRIPTION
Adds meta tags for twitter cards.

It looks like the card validator won't show the image, but it's because the URL is still looking at localhost (ngrok isn't *that* good!)

Card Validator: https://cards-dev.twitter.com/validator

Complementary screenshot:
<img width="517" alt="Screen Shot 2020-07-28 at 8 25 54 PM" src="https://user-images.githubusercontent.com/3891660/88746116-5e99ac00-d111-11ea-9a5e-d1e37162cadc.png">


@InessaPawson, to change what shows up in the card, you'll want to edit the description and image under the params object in the config.yaml. See examples here: https://gohugo.io/templates/internal/#twitter-cards

@rgommers, I don't know if we have some kind of staging any longer (I know our staging deployment site never worked that great), but it would be great to test it out there if possible. Otherwise, this is a pretty minor change that doesn't effect the site, only twitter cards.