### PR TITLE
DOC: Give bjnath's name on team page

### DIFF
--- a/static/gallery/team.html
+++ b/static/gallery/team.html
@@ -418,7 +418,7 @@
                     <img class="card-img-top" style="border-radius: 5%;" alt="" src="https://avatars1.githubusercontent.com/u/6691888?v=4"/>
                     <div class="card-body">
                         <h6 class="card-title">
-                            bjnath
+                            Ben Nathanson
                         </h6>
                         <p class="card-text small">
                             <a href="https://github.com/bjnath">bjnath</a>


### PR DESCRIPTION
Puts my name on the team page; currently has just my GitHub id, as explained in https://github.com/numpy/numpy.org/pull/351#issuecomment-671084374

This html file will be overwritten when the page is regenerated, but because I've now added my name to GitHub, the change will be in the new page as well. 