### PR TITLE
deploy via gh-pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,59 @@
-.PHONY: serve html clean github
+# type `make help` to see all options 
 
-serve:
-	@hugo --i18n-warnings server -D
+# If you have naively forked this repo, say to
+# github.com://myname/numpy.org.git, you can test out the build via
+# make TARGET=myname BASEURL=https://myname.github.io/numpy.org deploy
 
-html:
-	@hugo
-	@touch public/.nojekyll
+TARGET ?= origin
+BASEURL ?= 
 
-clean:
-	@rm -rf public
+ifeq ($(TARGET), origin)
+	WORKTREETARGET =
+else
+	WORKTREETARGET = "$(TARGET)/gh-pages"
+endif 
 
-github: | clean html
-	@echo "Command to upload to git goes here"
-	@echo "See `push_dir_to_repo.py` in NumPy"
+ifdef BASEURL
+	BASEURLARG=-b $(BASEURL)
+endif 
+
+all: build
+
+.PHONY: serve html clean deploy help
+
+.SILENT: # remove this to see the commands executed
+
+serve: public ## serve the website
+	hugo --i18n-warnings server -D
+
+public: ## create a worktree branch in the public directory
+	git worktree add -B gh-pages public $(WORKTREETARGET)
+	rm -rf public/*
+
+html: public ## build the website in ./public
+	hugo $(BASEURLARG)
+	touch public/.nojekyll
+
+public/.nojekyll: html
+
+clean: ## remove the build artifacts, mainly the "public" directory
+	rm -rf public
+	git worktree prune
+	rm -rf .git/wortrees/public
+
+deploy: public/.nojekyll ## push the built site to the gh-pages of this repo
+	cd public && git add --all && git commit -m"Publishing to gh-pages"
+	@echo pushint to $(TARGET) gh-pages
+	git push $(TARGET) gh-pages
+
+
+# Add help text after each target name starting with '\#\#'
+help:   ## Show this help.
+	@echo "\nHelp for this makefile"
+	@echo "Possible commands are:"
+	@grep -h "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/\(.*\):.*##\(.*\)/    \1: \2/'
+	@echo 
+	@echo If you have naively forked this repo, say to
+	@echo github.com://myname/numpy.org.git, you can test out the build via
+	@echo make TARGET=myname BASEURL=https://myname.github.io/numpy.org deploy
+ 

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,6 @@
 TARGET ?= origin
 BASEURL ?= 
 
-ifeq ($(TARGET), origin)
-	WORKTREETARGET =
-else
-	WORKTREETARGET = "$(TARGET)/gh-pages"
-endif 
-
 ifdef BASEURL
 	BASEURLARG=-b $(BASEURL)
 endif 
@@ -27,7 +21,7 @@ serve: public ## serve the website
 	hugo --i18n-warnings server -D
 
 public: ## create a worktree branch in the public directory
-	git worktree add -B gh-pages public $(WORKTREETARGET)
+	git worktree add -B gh-pages public $(TARGET)/gh-pages
 	rm -rf public/*
 
 html: public ## build the website in ./public
@@ -39,7 +33,7 @@ public/.nojekyll: html
 clean: ## remove the build artifacts, mainly the "public" directory
 	rm -rf public
 	git worktree prune
-	rm -rf .git/wortrees/public
+	rm -rf .git/worktrees/public
 
 deploy: public/.nojekyll ## push the built site to the gh-pages of this repo
 	cd public && git add --all && git commit -m"Publishing to gh-pages"


### PR DESCRIPTION
replaces #289 

This is based on the assumption that we still want a deploy workflow based on a local repo, not automated via CI.

The Makefile now has grown a few more options. The normal workflow would be `make clean; make html; make serve`, look at the local version or commit the changes and look at them via netlify. When a PR is merged to master,  `git checkout master; git pull; make serve`, look one more time, then `make deploy`. The pages will be put into a gh-pages branch and served via github pages from that branch.

Additionally, if you want to work on a fork, you can do all of the above with
`make TARGET=myname BASEURL=https://myname.github.io/numpy.org <command>`
which will deploy the pages to your fork, like [this](https://mattip.github.io/numpy.org/). It does take ~5 minutes for the pages to redeploy, so netlify may be a better preview mechanism. But sometimes you don't want to keep pushing little changes to this repo before squashing and opening a PR.

`make help` works and should show helpful text