### PR TITLE
DOC: Add ImportError link for Install page

### DIFF
--- a/content/en/install.md
+++ b/content/en/install.md
@@ -116,8 +116,7 @@ different reasons, often due to issues with your setup.
 
 ## Building from source
 
-For instructions on building for source package, see
-[Building from source](https://numpy.org/devdocs/user/building.html).
+See [Building from source](https://numpy.org/devdocs/user/building.html).
 
 
 ## Python package management

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -114,6 +114,10 @@ Importing the numpy c-extensions failed. This error can happen for
 different reasons, often due to issues with your setup.
 ```
 
+## Building from source
+
+For instructions on building for source package, see
+[Building from source](https://numpy.org/devdocs/user/building.html).
 
 
 ## Python package management

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -102,6 +102,20 @@ we recommend:
   in a similar fashion as conda does.
 
 
+## Troubleshooting ImportError
+
+If your installation fails with the message below, see [Troubleshooting
+ImportError](https://numpy.org/doc/stable/user/troubleshooting-importerror.html).
+
+```
+IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
+
+Importing the numpy c-extensions failed. This error can happen for
+different reasons, often due to issues with your setup.
+```
+
+
+
 ## Python package management
 
 Managing packages is a challenging problem, and, as a result, there are lots of


### PR DESCRIPTION
Give the Install page a pointer to the [Troubleshooting ImportError page](https://numpy.org/doc/stable/user/troubleshooting-importerror.html) in the Sphinx docs.
