### PR TITLE
Add NumPy Diversity and Inclusion Statement

### DIFF
--- a/content/en/diversity_sep2020.md
+++ b/content/en/diversity_sep2020.md
@@ -1,0 +1,99 @@
+---
+title: NumPy Diversity and Inclusion Statement
+sidebar: false
+---
+
+
+_In light of the foregoing discussion on social media after publication of the
+NumPy paper in Nature and the concerns raised about the state of diversity and
+inclusion on the NumPy team, we would like to issue the following statement:_
+
+
+It is our strong belief that we are at our best, as a team and community, when
+we are inclusive and equitable. Being an international team from the onset, we
+recognize the value of collaborating with individuals from diverse backgrounds
+and expertise. A culture where everyone is welcomed, supported, and valued is
+at the core of the NumPy project.
+
+## The Past
+
+Contributing to open source has always been a pastime in which most
+historically marginalized groups, especially women, faced more obstacles to
+participate due to a number of societal constraints and expectations.
+Open source has a severe diversity gap that is well documented (see, e.g., the
+[2017 GitHub Open Source Survey](https://opensourcesurvey.org/2017/) and
+[this blog post](https://medium.com/tech-diversity-files/if-you-think-women-in-tech-is-just-a-pipeline-problem-you-haven-t-been-paying-attention-cb7a2073b996)).
+
+Since its inception and until 2018, NumPy was maintained by a handful of
+volunteers often working nights and weekends outside of their day jobs. At any
+one time, the number of active core developers, the ones doing most of the
+heavy lifting as well as code review and integration of contributions from the
+community, was in the range of 4 to 8. The project didn't have a roadmap or
+mechanism for directing resources, being driven by individual efforts to work
+on what seemed needed. The authors on the NumPy paper are the individuals who
+made the most significant and sustained contributions to the project over a
+period of 15 years (2005 - 2019). The lack of diversity on this author list is
+a reflection of the formative years of the Python and SciPy ecosystems.
+
+2018 has marked an important milestone in the history of the NumPy project.
+Receiving funding from The Gordon and Betty Moore Foundation and Alfred P.
+Sloan Foundation allowed us to provide full-time employment for two software
+engineers with years of experience contributing to the Python ecosystem. Those
+efforts brought NumPy to a much healthier technical state.
+
+This funding also created space for NumPy maintainers to focus on project
+governance, community development, and outreach to underrepresented groups.
+[The diversity statement](https://figshare.com/articles/online_resource/Diversity_and_Inclusion_Statement_NumPy_for_Chan_Zuckerberg_Initiative_EOSS_2019_round_1/12980852)
+written in mid 2019 for the CZI EOSS program grant application details some of
+the challenges as well as the advances in our efforts to bring in more diverse
+talent to the NumPy team.
+
+## The Present
+
+Offering employment opportunities is an effective way to attract and retain
+diverse talent in OSS. Therefore, we used two-thirds of our second grant that
+became available in Dec 2019 to employ Melissa Weber Mendonça and Mars Lee.
+
+As a result of several initiatives aimed at community development and
+engagement led by Inessa Pawson and Ralf Gommers, the NumPy project has
+received a number of valuable contributions from women and other
+underrepresented groups in open source in 2020:
+
+- Melissa Weber Mendonça gained commit rights, is maintaining numpy.f2py and is
+  leading the documentation team,
+- Shaloo Shalini created all case studies on numpy.org,
+- Mars Lee contributed web design and led our accessibility improvements work,
+- Isabela Presedo-Floyd designed our new logo,
+- Stephanie Mendoza, Xiayoi Deng, Deji Suolang, and Mame Fatou Thiam
+  designed and fielded the first NumPy user survey,
+- Yuki Dunn, Dayane Machado, Mahfuza Humayra Mohona, Sumera Priyadarsini,
+  Shaloo Shalini, and Kriti Singh (former Outreachy intern) helped the
+  survey team to reach out to non-English speaking NumPy users and developers
+  by translating the questionnaire into their native languages,
+- Sayed Adel, Raghuveer Devulapalli, and Chunlin Fang are driving the work on
+  SIMD optimizations in the core of NumPy.
+
+While we still have much more work to do, the NumPy team is starting to look
+much more representative of our user base. And we can assure you that the next
+NumPy paper will certainly have a more diverse group of authors.
+
+## The Future
+
+We are fully committed to fostering inclusion and diversity on our team and in
+our community, and to do our part in building a more just and equitable future.
+
+We are open to dialogue and welcome every opportunity to connect with
+organizations representing and supporting women and minorities in tech and
+science. We are ready to listen, learn, and support.
+
+Please get in touch with us on [our mailing list](https://scipy.org/scipylib/mailing-lists.html#mailing-lists),
+[GitHub](https://github.com/numpy/numpy/issues), [Slack](https://numpy.org/contribute/),
+in private at numpy-team@googlegroups.com, or join our
+[bi-weekly community meeting](https://hackmd.io/76o-IxCjQX2mOXO_wwkcpg).
+
+
+_Sayed Adel, Sebastian Berg, Raghuveer Devulapalli, Chunlin Fang, Ralf Gommers,
+Allan Haldane, Stephan Hoyer, Mars Lee, Melissa Weber Mendonça, Jarrod Millman,
+Inessa Pawson, Matti Picus, Nathaniel Smith, Julian Taylor, Pauli Virtanen,
+Stéfan van der Walt, Eric Wieser, on behalf of the NumPy team_
+

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -3,6 +3,11 @@ title: News
 sidebar: false
 ---
 
+### Diversity in the NumPy project
+
+_Sep 20, 2020_ -- We wrote a [statement on the state of, and discussion on social media around, diversity and inclusion in the NumPy project](/diversity_sep2020).
+
+
 ### First official NumPy paper published in Nature!
 
 _Sep 16, 2020_ -- We are pleased to announce the publication of

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -3,6 +3,17 @@ title: News
 sidebar: false
 ---
 
+### First official NumPy paper published in Nature!
+
+_Sep 16, 2020_ -- We are pleased to announce the publication of
+[the first official paper on NumPy](https://www.nature.com/articles/s41586-020-2649-2)
+as a review article in Nature. This comes 14 years after the release of NumPy 1.0.
+The paper covers applications and fundamental concepts of array programming,
+the rich scientific Python ecosystem built on top of NumPy, and the recently added
+array protocols to facilitate interoperability with external array and tensor
+libraries like CuPy, Dask, and JAX.
+
+
 ### Python 3.9 is coming, when will NumPy release binary wheels?
 
 _Sept 14, 2020_ -- Python 3.9 will be released in a few weeks. If you are an


### PR DESCRIPTION
Also adds a short News entry about the Nature paper.

Already up at https://numpy.org/diversity_sep2020/ (it was thoroughly reviewed outside of GitHub), so merging straight away.