### PR TITLE
Install page update

### DIFF
--- a/content/en/install.md
+++ b/content/en/install.md
@@ -167,15 +167,7 @@ The second difference is that pip installs from the Python Packaging Index
 "conda-forge"). PyPI is the largest collection of packages by far, however, all
 popular packages are available for conda as well.
 
-The third difference is that pip does not have a _dependency resolver_ (this is
-expected to change in the near future), while conda does. For simple cases (e.g.
-you just want NumPy, SciPy, Matplotlib, Pandas, Scikit-learn, and a few other
-packages) that doesn't matter, however, for complicated cases conda can be
-expected to do a better job keeping everything working well together. The flip
-side of that coin is that installing with pip is typically a _lot_ faster than
-installing with conda.
-
-The fourth difference is that conda is an integrated solution for managing
+The third difference is that conda is an integrated solution for managing
 packages, dependencies and environments, while with pip you may need another
 tool (there are many!) for dealing with environments or complex dependencies.
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -9,8 +9,9 @@ Python yet and want the simplest way to get started, we recommend you use the
 Python, NumPy, and many other commonly used packages for scientific computing
 and data science.
 
-NumPy can be installed with `conda`, with `pip`, or with a package manager on
-macOS and Linux. For more detailed instructions, consult our [Python and NumPy
+NumPy can be installed with `conda`, with `pip`, with a package manager on
+macOS and Linux, or [from source](https://numpy.org/devdocs/user/building.html).
+For more detailed instructions, consult our [Python and NumPy
 installation guide](#python-numpy-install-guide) below.
 
 ## conda
@@ -131,10 +132,6 @@ IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
 Importing the numpy c-extensions failed. This error can happen for
 different reasons, often due to issues with your setup.
 ```
-
-## Building from source
-
-See [Building from source](https://numpy.org/devdocs/user/building.html).
 
 
 ## Python package management

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -3,25 +3,43 @@ title: Installing NumPy
 sidebar: false
 ---
 
-The only prerequisite for NumPy is Python itself. If you don't have Python yet and want the simplest way to get started, we recommend you use the [Anaconda Distribution](https://www.anaconda.com/distribution) - it includes Python, NumPy, and other commonly used packages for scientific computing and data science.
+The only prerequisite for installing NumPy is Python itself. If you don't have
+Python yet and want the simplest way to get started, we recommend you use the
+[Anaconda Distribution](https://www.anaconda.com/distribution) - it includes
+Python, NumPy, and many other commonly used packages for scientific computing
+and data science.
 
-NumPy can be installed with `conda`, with `pip`, or with a package manager on macOS and Linux. For more detailed instructions, consult our [Python and NumPy installation guide](#python-numpy-install-guide) below.
+NumPy can be installed with `conda`, with `pip`, or with a package manager on
+macOS and Linux. For more detailed instructions, consult our [Python and NumPy
+installation guide](#python-numpy-install-guide) below.
 
 ## conda
 
-If you use `conda`, you can install it with:
+If you use `conda`, you can install NumPy from the `defaults` or `conda-forge`
+channels:
 
 ```bash
+# Best practice, use an environment rather than install in the base env
+conda create -n my-env
+conda activate my-env
+# If you want to install from conda-forge
+conda config --env --add channels conda-forge
+# The actual install command
 conda install numpy
 ```
 
 ## pip
 
-If you use `pip`, you can install it with:
+If you use `pip`, you can install NumPy with:
 
 ```bash
 pip install numpy
 ```
+Also when using pip, it's good practice to use a virtual environment -
+see  [Reproducible Installs](#reproducible-installs) below for why, and
+[this guide](https://dev.to/bowmanjd/python-tools-for-managing-virtual-environments-3bko#howto)
+for details on using virtual environments.
+
 
 <a name="python-numpy-install-guide"></a>
 # Python and NumPy installation guide

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -14,7 +14,7 @@ macOS and Linux, or [from source](https://numpy.org/devdocs/user/building.html).
 For more detailed instructions, consult our [Python and NumPy
 installation guide](#python-numpy-install-guide) below.
 
-## conda
+**CONDA**
 
 If you use `conda`, you can install NumPy from the `defaults` or `conda-forge`
 channels:
@@ -29,7 +29,7 @@ conda config --env --add channels conda-forge
 conda install numpy
 ```
 
-## pip
+**PIP**
 
 If you use `pip`, you can install NumPy with:
 
@@ -121,19 +121,6 @@ we recommend:
   in a similar fashion as conda does.
 
 
-## Troubleshooting ImportError
-
-If your installation fails with the message below, see [Troubleshooting
-ImportError](https://numpy.org/doc/stable/user/troubleshooting-importerror.html).
-
-```
-IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
-
-Importing the numpy c-extensions failed. This error can happen for
-different reasons, often due to issues with your setup.
-```
-
-
 ## Python package management
 
 Managing packages is a challenging problem, and, as a result, there are lots of
@@ -222,4 +209,17 @@ consider:
   function calls. It can also be harmful for performance, for example when
   using another level of parallelization manually or with, e.g. Dask or
   scikit-learn functionality.
+
+
+## Troubleshooting
+
+If your installation fails with the message below, see [Troubleshooting
+ImportError](https://numpy.org/doc/stable/user/troubleshooting-importerror.html).
+
+```
+IMPORTANT: PLEASE READ THIS FOR ADVICE ON HOW TO SOLVE THIS ISSUE!
+
+Importing the numpy c-extensions failed. This error can happen for
+different reasons, often due to issues with your setup.
+```
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -182,36 +182,18 @@ tool (there are many!) for dealing with environments or complex dependencies.
 
 ### Reproducible installs
 
-Making the installation of all the packages your analysis, library or
-application depends on reproducible is important. Sounds obvious, yet most
-users don't think about doing this (at least until it's too late).
+As libraries get updated, results from running your code can change, or your
+code can break completely. It's important to be able to reconstruct the set
+of packages and versions you're using. Best practice is to:
 
-The problem with Python packaging is that sooner or later, something will
-break. It's not often this bad,
-
-{{< figure src="/images/content_images/python_environment_xkcd.png"
-           alt="Python Environment XKCD image"
-           link="https://xkcd.com/1987/"
-           width="400"
-           attr="_XKCD illustration - Python environment degradation_">}}
-
-but it does degrade over time. Hence, it's important to be able to delete and
-reconstruct the set of packages you have installed.
-
-Best practice is to use a different environment per project you're working on,
-and record at least the names (and preferably versions) of the packages you
-directly depend on in a static metadata file. Each packaging tool has its own
-metadata format for this:
-- Conda: [conda environments and environment.yml](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#)
-- Pip: [virtual environments](https://docs.python.org/3/tutorial/venv.html) and
+1. use a different environment per project you're working on,
+2. record package names and versions using your package installer;
+   each has its own metadata format for this:
+   - Conda: [conda environments and environment.yml](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#)
+   - Pip: [virtual environments](https://docs.python.org/3/tutorial/venv.html) and
   [requirements.txt](https://pip.readthedocs.io/en/latest/user_guide/#requirements-files)
-- Poetry: [virtual environments and pyproject.toml](https://python-poetry.org/docs/basic-usage/)
+   - Poetry: [virtual environments and pyproject.toml](https://python-poetry.org/docs/basic-usage/)
 
-Sometimes it's too much overhead to create and switch between new environments
-for small tasks. In that case we encourage you to not install too many packages
-into your base environment, and keep track of versions of packages some other
-way (e.g. comments inside files, or printing `numpy.__version__` after
-importing it in notebooks).
 
 
 ## NumPy packages & accelerated linear algebra libraries

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -178,27 +178,33 @@ NumPy doesn't depend on any other Python packages, however, it does depend on an
 accelerated linear algebra library - typically
 [Intel MKL](https://software.intel.com/en-us/mkl) or
 [OpenBLAS](https://www.openblas.net/). Users don't have to worry about
-installing those, but it may still be important to understand how the packaging
-is done and how it affects performance and behavior users see.
+installing those (they're automatically included in all NumPy install methods).
+Power users may still want to know the details, because the used BLAS can
+affect performance, behavior and size on disk:
 
-The NumPy wheels on PyPI, which is what pip installs, are built with OpenBLAS.
-The OpenBLAS libraries are shipped within the wheels itself. This makes those
-wheels larger, and if a user installs (for example) SciPy as well, they will
-now have two copies of OpenBLAS on disk.
+- The NumPy wheels on PyPI, which is what pip installs, are built with OpenBLAS.
+  The OpenBLAS libraries are included in the wheel. This makes the wheel
+  larger, and if a user installs (for example) SciPy as well, they will now
+  have two copies of OpenBLAS on disk.
 
-In the conda defaults channel, NumPy is built against Intel MKL. MKL is a
-separate package that will be installed in the users' environment when they
-install NumPy. That MKL package is a lot larger than OpenBLAS, several hundred
-MB. MKL is typically a little faster and more robust than OpenBLAS.
+- In the conda defaults channel, NumPy is built against Intel MKL. MKL is a
+  separate package that will be installed in the users' environment when they
+  install NumPy.
 
-In the conda-forge channel, NumPy is built against a dummy "BLAS" package. When
-a user installs NumPy from conda-forge, that BLAS package then gets installed
-together with the actual library - this defaults to OpenBLAS, but it can also
-be MKL (from the defaults channel), or even
-[BLIS](https://github.com/flame/blis) or reference BLAS.
+- In the conda-forge channel, NumPy is built against a dummy "BLAS" package. When
+  a user installs NumPy from conda-forge, that BLAS package then gets installed
+  together with the actual library - this defaults to OpenBLAS, but it can also
+  be MKL (from the defaults channel), or even
+  [BLIS](https://github.com/flame/blis) or reference BLAS.
+
+- The MKL package is a lot larger than OpenBLAS, it's about 700 MB on disk
+  while OpenBLAS is about 30 MB.
+
+- MKL is typically a little faster and more robust than OpenBLAS.
 
 Besides install sizes, performance and robustness, there are two more things to
 consider:
+
 - Intel MKL is not open source. For normal use this is not a problem, but if
   a user needs to redistribute an application built with NumPy, this could be
   an issue.
@@ -206,9 +212,9 @@ consider:
   `np.dot`, with the number of threads being determined by both a build-time
   option and an environment variable. Often all CPU cores will be used. This is
   sometimes unexpected for users; NumPy itself doesn't auto-parallelize any
-  function calls. It can also be harmful for performance, for example when
-  using another level of parallelization manually or with, e.g. Dask or
-  scikit-learn functionality.
+  function calls. It typically yields better performance, but can also be
+  harmful - for example when using another level of parallelization with Dask,
+  scikit-learn or multiprocessing.
 
 
 ## Troubleshooting


### PR DESCRIPTION
This is a continuation of gh-298. It takes over some changes from that PR, and adds new content based on review suggestions there.

- add using virtual environments to install commands in main section
- edit reproducible installs section
- update pip/conda and MKL/OpenBLAS parts
- clean up section headers and sidebar