### PR TITLE
Add overflow: auto to .content-container to fix install page

### DIFF
--- a/static/css/content.css
+++ b/static/css/content.css
@@ -13,6 +13,7 @@
 .content-container {
     max-width: 850px;
     margin: 0 30px;
+    overflow: auto;
 }
 
 .content-container ul {


### PR DESCRIPTION
Fixes #375.

This appears to work fine with the other content pages in both mobile and desktop. This enables scrolling in the code blocks, so while you have to scroll to see the overflowing code content, the rest of the page is viewable. 