### PR TITLE
Create Github Actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,30 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.74.3' # Locked version, see issue #363
+          extended: true
+
+      - name: Build
+        run: hugo
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public


### PR DESCRIPTION
This action uses [GitHub Actions for GitHub Pages](https://github.com/peaceiris/actions-gh-pages) to deploy to the `gh-pages` branch, using mostly the examples in that repo's readme.

This works only on the master branch. The `gh-pages.yml` config should fetch our submodules, install `0.74.3/extended`, build, and update the `gh-pages` branch.

This is supposed to work 'out of the box' with the `GITHUB_TOKEN` token-- the docs mention this is created by the Github Actions runner.

@mattip @rgommers let me know if I'm missing anything here, happy to update this pr!

