### PR TITLE
Revert "Add CNAME during deployment to gh-pages"

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,4 +28,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          cname: numpy.org


### PR DESCRIPTION
Reverts numpy/numpy.org#379

See https://github.com/numpy/numpy.github.com/pull/1