### PR TITLE
Update Github Action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,3 +1,4 @@
+# https://github.com/chabad360/hugo-gh-pages
 name: github pages
 
 on:
@@ -6,25 +7,18 @@ on:
       - master
 
 jobs:
-  deploy:
-    runs-on: ubuntu-18.04
+  build-deploy:
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout Repo
+        uses: actions/checkout@master
         with:
-          submodules: true  # Fetch Hugo themes (true OR recursive)
-          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
-
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v2
+          hugoVersion: 'extended_0.74.3' # Locked version, see issue #363
+          submodules: true
+      - name: Publish Site
+        uses: chabad360/hugo-gh-pages@master
         with:
-          hugo-version: '0.74.3' # Locked version, see issue #363
-          extended: true
-
-      - name: Build
-        run: hugo
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
+          branch: master
+          repo: numpy/numpy.github.com
+          siteDir: /github/workspace/public
+          githubToken: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
Resolves #384.

Update Github Action to use the new `chabad360/hugo-gh-pages` version. This allows us to push the build to a different repository.

This hasn't been tested as it's set up for master.