### PR TITLE
Update .content-container

### DIFF
--- a/static/css/content.css
+++ b/static/css/content.css
@@ -13,7 +13,7 @@
 .content-container {
     max-width: 850px;
     margin: 0 30px;
-    overflow: auto;
+    overflow: hidden;
 }
 
 .content-container ul {


### PR DESCRIPTION
Replace overflow: auto; with overflow: hidden. This is for content pages, as a horizontal scroll was appearing at the bottom of the page.

Resolves #395

