### PR TITLE
Specify RGB values in the docs regarding the NumPy website color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,20 @@ if you don't have the Hugo extended version.
 
 ### NumPy Color Palette
 
-![#013243 Warm Black](./static/images/content_images/swatch_013243_warm_black.png) `#013243` **Warm Black**
+![#013243 Warm Black](./static/images/content_images/swatch_013243_warm_black.png) `RGB 1/50/67 | HEX #013243` 
 
-![#4D77CF Han Blue](./static/images/content_images/swatch_4D77CF_han_blue.png) `#4D77CF` **Han Blue**
+![#4D77CF Han Blue](./static/images/content_images/swatch_4D77CF_han_blue.png) `RGB 77/119/207 | HEX #4D77CF` 
 
-![#4DABCF Maximum Blue](./static/images/content_images/swatch_4DABCF_maximum_blue.png) `#4DABCF` **Maximum Blue**
+![#4DABCF Maximum Blue](./static/images/content_images/swatch_4DABCF_maximum_blue.png) `RGB 77/171/207 | HEX #4DABCF` 
 
-![#6C7A89 Aurometalsaurus](./static/images/content_images/swatch_6C7A89_aurometalsaurus.png) `#6C7A89` **Aurometalsaurus**
+![#6C7A89 Aurometalsaurus](./static/images/content_images/swatch_6C7A89_aurometalsaurus.png) `RGB 108/122/137 | HEX #6C7A89` 
 
-![#EEEEEE Isabelline](./static/images/content_images/swatch_EEEEEE_isabelline.png) `#EEEEEE` **Isabelline**
+![#EEEEEE Isabelline](./static/images/content_images/swatch_EEEEEE_isabelline.png) `RGB 238/238/238 | HEX #EEEEEE` 
 
-![#FFC553 Mustard](./static/images/content_images/swatch_FFC553_mustard.png) `#FFC553` **Mustard**
+![#FFC553 Mustard](./static/images/content_images/swatch_FFC553_mustard.png) `RGB 255/197/83 | HEX #FFC553` 
 
-![#FFFFFF White](./static/images/content_images/swatch_FFFFFF_white.png) `#FFFFFF` **White**
+![#FFFFFF White](./static/images/content_images/swatch_FFFFFF_white.png) `RGB 255/255/255 | HEX #FFFFFF` 
+
 
 ## Deployment
 


### PR DESCRIPTION
Specifying RGB values in the docs regarding the NumPy website color palette. Partially fixes #numpygh-398 numpy/numpy.org#398.



