### PR TITLE
Add a link to numpy.org/citing-numpy/ in the footer

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -119,6 +119,8 @@ languages:
               link: https://numpy.org/doc/stable
             - text: Learn
               link: /learn
+            - text: Citing Numpy
+              link: /citing-numpy
             - text: Roadmap
               link: https://numpy.org/neps/roadmap.html
         column2:


### PR DESCRIPTION
Add a link to https://numpy.org/citing-numpy/ in the footer. Fixes #406

_Note:_ All the pages linked in the footer that could be possibly replaced are in the top 20 for page views (total and unique) according to Google Analytics. Hence, the proposed solution.

