### PR TITLE
Add space for key features titles

### DIFF
--- a/static/css/keyfeatures.css
+++ b/static/css/keyfeatures.css
@@ -14,10 +14,10 @@
 }
 
 .keyfeatures-box-content {
-    height: 175px;
+    height: 200px;
     min-width: 275px;
-    width: 325px;
-    margin: 15px auto;
+    width: 335px;
+    margin: 25px auto;
     border-radius: 3px;
 }
 
@@ -32,8 +32,20 @@
 }
 
 .keyfeatures-box-text {
-    margin: 15px 15px;
+    margin: 15px;
     font-size: 14px;
+    overflow: hidden;
+}
+
+.keyfeatures-box-text:after {
+    content: "";
+    text-align: right;
+    position: absolute;
+    bottom:30px;
+    right: 0;
+    width: 70%;
+    height: 1.2em;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 50%);
 }
 
 .keyfeatures-box-content:hover > .keyfeatures-box-text, .keyfeatures-box-content:focus > .keyfeatures-box-text, .keyfeatures-box-content:active > .keyfeatures-box-text {

--- a/static/css/keyfeatures.css
+++ b/static/css/keyfeatures.css
@@ -34,6 +34,7 @@
 .keyfeatures-box-text {
     margin: 15px;
     font-size: 14px;
+    height: 6em;
     overflow: hidden;
 }
 


### PR DESCRIPTION
Resolves #417.

Adds additional space for 'key features' boxes on the home page. Also adds a fade for expanded content as shown here:

<img width="1222" alt="Screen Shot 2021-05-02 at 10 01 27 PM" src="https://user-images.githubusercontent.com/3891660/116876278-d5ecf680-abe1-11eb-9deb-05c3c08372a8.png">
