### PR TITLE
Add the news about the 2020 NumPy survey results

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -17,8 +17,8 @@ params:
     image: logos/numpy.svg
   # Customizable navbar. For a dropdown, add a "sublinks" list.
   news:
-    title: NumPy v1.20.0
-    content: Type annotation support - Performance improvements through multi-platform SIMD
+    title: 2020 NumPy survey  
+    content: results are in
     url: /news
 
   shell:

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -2,6 +2,10 @@
 title: News
 sidebar: false
 ---
+### 2020 NumPy survey results
+
+_Jun 22, 2021_ -- In 2020, the NumPy survey team in partnership with students and faculty from the University of Michigan and the University of Maryland conducted the first official NumPy community survey. Find the survey results here: https://numpy.org/user-survey-2020/.
+
 
 ### Numpy 1.20.0 release
 


### PR DESCRIPTION
Updating the news bar on the home page and news.md to announce the release of the 2020 NumPy survey findings.
