### PR TITLE
Add content from Sphinx docs to unify governance pages

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -48,6 +48,14 @@ The NumPy project is growing; we have teams for
 
 See the [Team](/gallery/team.html) page for individual team members.
 
+## NumFOCUS Subcommittee
+
+- Charles Harris
+- Ralf Gommers
+- Melissa Weber Mendonça
+- Sebastian Berg
+- External member: Thomas Caswell
+
 ## Sponsors
 
 NumPy receives direct funding from the following sources:
@@ -57,6 +65,10 @@ NumPy receives direct funding from the following sources:
 ## Institutional Partners
 
 Institutional Partners are organizations that support the project by employing people that contribute to NumPy as part of their job. Current Institutional Partners include:
+
+- UC Berkeley (Stéfan van der Walt, Sebastian Berg, Ross Barnowski)
+- Quansight (Ralf Gommers, Melissa Weber Mendonça, Mars Lee, Matti Picus, Pearu Peterson)
+
 {{< partners >}}
 
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

This PR adds information about institutional partners and the NumFOCUS subcommittee, with the goal of unifying the governance pages about people (currently, almost identical content appears in [the Sphinx documentation](https://numpy.org/devdocs/dev/governance/people.html) and [the About Us page](https://numpy.org/about/). 

If this PR is accepted, we can eliminate the page in the Sphinx docs.

Partially addresses numpy/numpy#17496

