### PR TITLE
Fix displayed DOI in citing-numpy.md

### DIFF
--- a/content/en/citing-numpy.md
+++ b/content/en/citing-numpy.md
@@ -5,7 +5,7 @@ sidebar: false
 
 If NumPy has been significant in your research, and you would like to acknowledge the project in your academic publication, we suggest citing the following paper:
 
-*  Harris, C.R., Millman, K.J., van der Walt, S.J. et al. _Array programming with NumPy_. Nature 585, 357–362 (2020). DOI: [0.1038/s41586-020-2649-2](https://doi.org/10.1038/s41586-020-2649-2). ([Publisher link](https://www.nature.com/articles/s41586-020-2649-2)).
+*  Harris, C.R., Millman, K.J., van der Walt, S.J. et al. _Array programming with NumPy_. Nature 585, 357–362 (2020). DOI: [10.1038/s41586-020-2649-2](https://doi.org/10.1038/s41586-020-2649-2). ([Publisher link](https://www.nature.com/articles/s41586-020-2649-2)).
 
 _In BibTeX format:_
 

--- a/content/ja/citing-numpy.md
+++ b/content/ja/citing-numpy.md
@@ -5,7 +5,7 @@ sidebar: false
 
 もしあなたの研究においてNumPyが重要な役割を果たし、論文でこのプロジェクトについて言及したい場合は、こちらの論文を引用して下さい。
 
-*  Harris, C.R., Millman, K.J., van der Walt, S.J. et al. _Array programming with NumPy_. Nature 585, 357–362 (2020). DOI: [0.1038/s41586-020-2649-2](https://doi. org/10.1038/s41586-020-2649-2). ([リンク](https://www.nature.com/articles/s41586-020-2649-2)).
+*  Harris, C.R., Millman, K.J., van der Walt, S.J. et al. _Array programming with NumPy_. Nature 585, 357–362 (2020). DOI: [10.1038/s41586-020-2649-2](https://doi.org/10.1038/s41586-020-2649-2). ([リンク](https://www.nature.com/articles/s41586-020-2649-2)).
 
 _BibTeX形式:_
 

--- a/content/pt/citing-numpy.md
+++ b/content/pt/citing-numpy.md
@@ -5,7 +5,7 @@ sidebar: false
 
 Se a NumPy é importante na sua pesquisa, e você gostaria de dar reconhecimento ao projeto na sua publicação acadêmica, sugerimos citar os seguintes documentos:
 
-*  Harris, C.R., Millman, K.J., van der Walt, S.J. et al. _Array programming with NumPy_. Nature 585, 357–362 (2020). DOI: [0.1038/s41586-020-2649-2](https://doi.org/10.1038/s41586-020-2649-2). ([Link da editora](https://www.nature.com/articles/s41586-020-2649-2)).
+*  Harris, C.R., Millman, K.J., van der Walt, S.J. et al. _Array programming with NumPy_. Nature 585, 357–362 (2020). DOI: [10.1038/s41586-020-2649-2](https://doi.org/10.1038/s41586-020-2649-2). ([Link da editora](https://www.nature.com/articles/s41586-020-2649-2)).
 
 _Em formato BibTeX:_
 


### PR DESCRIPTION

#### Brief description of what is fixed or changed

This PR changes the displayed DOI in `en` and `pt` localization of citing-numpy.md (a '1' was missing while the link was correct).

In the `ja` translation, additionally, a space is removed from the DOI link.

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

