### PR TITLE
Update default NumPy branch

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -5,7 +5,7 @@ sidebar: false
 
 _Some information about the NumPy project and community_
 
-NumPy is an open source project aiming to enable numerical computing with Python. It was created in 2005, building on the early work of the Numeric and Numarray libraries. NumPy will always be 100% open source software, free for all to use and released under the liberal terms of the [modified BSD license](https://github.com/numpy/numpy/blob/master/LICENSE.txt).
+NumPy is an open source project aiming to enable numerical computing with Python. It was created in 2005, building on the early work of the Numeric and Numarray libraries. NumPy will always be 100% open source software, free for all to use and released under the liberal terms of the [modified BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt).
 
 NumPy is developed in the open on GitHub, through the consensus of the NumPy and wider scientific Python community. For more information on our governance approach, please see our [Governance Document](https://www.numpy.org/devdocs/dev/governance/index.html).
 

--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -78,7 +78,7 @@ params:
     - title: Easy to use
       text: NumPy's high level syntax makes it accessible and productive for programmers from any background or experience level.
     - title: Open source
-      text: Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/master/LICENSE.txt), NumPy is developed and maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
+      text: Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt), NumPy is developed and maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
   tabs:
     title: ECOSYSTEM
   section5: false

--- a/content/en/press-kit.md
+++ b/content/en/press-kit.md
@@ -5,4 +5,4 @@ sidebar: false
 
 We would like to make it easy for you to include the NumPy project identity in your next academic paper, course materials, or presentation. 
 
-You will find several high-resolution versions of the NumPy logo [here](https://github.com/numpy/numpy/tree/master/branding/logo). Note that by using the numpy.org resources, you accept the [NumPy Code of Conduct](/code-of-conduct).
+You will find several high-resolution versions of the NumPy logo [here](https://github.com/numpy/numpy/tree/main/branding/logo). Note that by using the numpy.org resources, you accept the [NumPy Code of Conduct](/code-of-conduct).

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -5,7 +5,7 @@ sidebar: false
 
 _このページでは、NumPyのプロジェクトとそれを支えるコミュニティについて説明します。_
 
-NumPy は、Python で数値計算を可能にするためのオープンソースプロジェクトです。 NumPyは、NumericやNumarrayといった初期のライブラリのコードをもとに、2005年から開発が開始されました。 NumPyは完全にオープンソースなソフトウェアであり、[修正BSD ライセンス](https://github.com/numpy/numpy/blob/master/LICENSE.txt) の条項の下で、すべての人が利用可能です。
+NumPy は、Python で数値計算を可能にするためのオープンソースプロジェクトです。 NumPyは、NumericやNumarrayといった初期のライブラリのコードをもとに、2005年から開発が開始されました。 NumPyは完全にオープンソースなソフトウェアであり、[修正BSD ライセンス](https://github.com/numpy/numpy/blob/main/LICENSE.txt) の条項の下で、すべての人が利用可能です。
 
 NumPy は 、NumPyコミュニティやより広範な科学計算用Python コミュニティとの合意のもと、GitHub 上でオープンに開発されています。 NumPyのガバナンス方法の詳細については、 [Governance Document](https://www.numpy.org/devdocs/dev/governance/index.html) をご覧ください。
 

--- a/content/ja/config.yaml
+++ b/content/ja/config.yaml
@@ -83,7 +83,7 @@ params:
     - title: 使いやすさ
       text: NumPyの高水準なシンタックスは、どんなバックグラウンドや経験値のプログラマーでも利用でき、生産性を高めることができます。
     - title: オープンソース
-      text: 寛容な[BSDライセンス](https://github.com/numpy/numpy/blob/master/LICENSE.txt)で公開されています。NumPyは活発で、互いを尊重し、多様性を認め合う[コミュニティ](/ja/community)によって、 [GitHub](https://github.com/numpy/numpy)上でオープンに開発されています.
+      text: 寛容な[BSDライセンス](https://github.com/numpy/numpy/blob/main/LICENSE.txt)で公開されています。NumPyは活発で、互いを尊重し、多様性を認め合う[コミュニティ](/ja/community)によって、 [GitHub](https://github.com/numpy/numpy)上でオープンに開発されています.
 
   tabs:
     title: エコシステム

--- a/content/ja/press-kit.md
+++ b/content/ja/press-kit.md
@@ -5,4 +5,4 @@ sidebar: false
 
 私たちはユーザーの皆さんが次に書く学術論文や、コース教材、プレゼンテーションなどに、NumPyプロジェクトのロゴを簡単に盛り込めるようにしたいと考えています。
 
-こちらから、様々な解像度のNumPyロゴのファイルをダウンロードできます: [ロゴリンク](https://github.com/numpy/numpy/tree/master/branding/logo)。numpy.orgのリソースを使用することで、[NumPy行動規範](/code-of-conduct) を受け入れたことになることに注意してください。
+こちらから、様々な解像度のNumPyロゴのファイルをダウンロードできます: [ロゴリンク](https://github.com/numpy/numpy/tree/main/branding/logo)。numpy.orgのリソースを使用することで、[NumPy行動規範](/code-of-conduct) を受け入れたことになることに注意してください。

--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -5,7 +5,7 @@ sidebar: false
 
 _Algumas informações sobre o projeto NumPy e a comunidade_
 
-NumPy é um projeto de código aberto visando habilitar a computação numérica com Python. Foi criado em 2005, com base no trabalho inicial das bibliotecas Numeric e Numarray. O NumPy sempre será um software 100% de código aberto, livre para que todos usem e disponibilizados sob os termos liberais da [licença BSD modificada](https://github.com/numpy/numpy/blob/master/LICENSE.txt).
+NumPy é um projeto de código aberto visando habilitar a computação numérica com Python. Foi criado em 2005, com base no trabalho inicial das bibliotecas Numeric e Numarray. O NumPy sempre será um software 100% de código aberto, livre para que todos usem e disponibilizados sob os termos liberais da [licença BSD modificada](https://github.com/numpy/numpy/blob/main/LICENSE.txt).
 
 O NumPy é desenvolvido no GitHub, através do consenso da comunidade NumPy e de uma comunidade científica em Python mais ampla. Para obter mais informações sobre nossa abordagem de governança, por favor, consulte nosso [Documento de Governança](https://www.numpy.org/devdocs/dev/governance/index.html).
 

--- a/content/pt/config.yaml
+++ b/content/pt/config.yaml
@@ -82,7 +82,7 @@ params:
     - title: Fácil de usar
       text: A sintaxe de alto nível do NumPy torna-o acessível e produtivo para programadores de qualquer nível de experiência e formação.
     - title: Código aberto
-      text: Distribuido com uma [licença BSD](https://github.com/numpy/numpy/blob/master/LICENSE.txt) liberal, o NumPy é desenvolvido e mantido [publicamente no GitHub](https://github.com/numpy/numpy) por uma [comunidade](/pt/community) vibrante, responsiva, e diversa.
+      text: Distribuido com uma [licença BSD](https://github.com/numpy/numpy/blob/main/LICENSE.txt) liberal, o NumPy é desenvolvido e mantido [publicamente no GitHub](https://github.com/numpy/numpy) por uma [comunidade](/pt/community) vibrante, responsiva, e diversa.
 
   tabs:
     title: ECOSSISTEMA

--- a/content/pt/press-kit.md
+++ b/content/pt/press-kit.md
@@ -5,4 +5,4 @@ sidebar: false
 
 Gostaríamos de facilitar a inclusão da identidade do projeto NumPy em seu próximo documento acadêmico, materiais educacionais ou apresentação.
 
-Você encontrará várias versões de alta resolução do logo do NumPy [aqui](https://github.com/numpy/numpy/tree/master/branding/logo). Note que usando os recursos numpy.org, você aceita o [Código de Conduta do NumPy](/code-of-conduct).
+Você encontrará várias versões de alta resolução do logo do NumPy [aqui](https://github.com/numpy/numpy/tree/main/branding/logo). Note que usando os recursos numpy.org, você aceita o [Código de Conduta do NumPy](/code-of-conduct).


### PR DESCRIPTION
This replaces
- `github.com/numpy/numpy/tree/master/` with `github.com/numpy/numpy/tree/main/`

and

- `github.com/numpy/numpy/blob/master/` with `github.com/numpy/numpy/blob/main/`

This reflects the change from `master` to `main` as the name of the default branch.