### PR TITLE
Fixed broken link to the VisPy gallery

### DIFF
--- a/content/en/tabcontents.yaml
+++ b/content/en/tabcontents.yaml
@@ -173,7 +173,7 @@ visualization:
   - url: https://napari.org
     img: /images/content_images/v_napari.png
     alttext:  A multi-dimensionan image made in napari.
-  - url: http://vispy.org/gallery.html
+  - url: https://vispy.org/gallery/index.html
     img: /images/content_images/v_vispy.png
     alttext:  A Voronoi diagram made in vispy.
   

--- a/content/ja/tabcontents.yaml
+++ b/content/ja/tabcontents.yaml
@@ -173,7 +173,7 @@ visualization:
   - url: https://napari.org
     img: /images/content_images/v_napari.png
     alttext:  A multi-dimensionan image made in napari.
-  - url: http://vispy.org/gallery.html
+  - url: https://vispy.org/gallery/index.html
     img: /images/content_images/v_vispy.png
     alttext:  A Voronoi diagram made in vispy.
   

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -173,7 +173,7 @@ visualization:
   - url: https://napari.org
     img: /images/content_images/v_napari.png
     alttext:  A multi-dimensionan image made in napari.
-  - url: http://vispy.org/gallery.html
+  - url: https://vispy.org/gallery/index.html
     img: /images/content_images/v_vispy.png
     alttext:  A Voronoi diagram made in vispy.
   


### PR DESCRIPTION

Replaced http://vispy.org/gallery.html to https://vispy.org/gallery/index.html

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

