### PR TITLE
Restore mailchip css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 public/
 resources/
 config.yaml
+.hugo_build.lock
 
 *.swp
 *.pyd

--- a/assets/css/mailchimp.css
+++ b/assets/css/mailchimp.css
@@ -1,7 +1,6 @@
-$numpySlateGray: rgb(108, 122, 137);
-
-$colorPrimaryDark: rgb(1, 50, 67);
-$colorPrimaryLight: rgb(238, 238, 238); 
+:root {
+  --numpySlateGray: rgb(108, 122, 137);
+}
 
 .sign-up-container {
   display: flex;
@@ -13,27 +12,27 @@ $colorPrimaryLight: rgb(238, 238, 238);
 
 .sign-up-image {
   padding: 5px 10px 6px 10px;
-  border-right: 1px solid $colorPrimaryLight;
-  background-color: $colorPrimaryLight;
+  border-right: 1px solid var(--colorSecondary);
+  background-color: var(--colorSecondary);
   border-radius: 5px 0 0 5px;
 }
 
 .sign-up-input {
-  background-color: $colorPrimaryLight;
+  background-color: var(--colorSecondary);
   border-radius: 0 5px 5px 0;
   border: none;
   width: 75%;
   height: 35px;
   padding-left: 5px;
   font-size: 14px;
-  color: $colorPrimaryDark;
+  color: var(--colorPrimaryDark);
 }
 
 .submission-instructions {
   position: absolute;
   right: 18%;
   font-size: 10px;
-  color: $numpySlateGray;
+  color: var(--numpySlateGray);
 }
 
 .signup-button {
@@ -43,9 +42,9 @@ $colorPrimaryLight: rgb(238, 238, 238);
 .thank-you {
   display: none;
   height: 75px;
-  color: $colorPrimaryLight;
+  color: var(--colorSecondary);
   align-items: center;
-  color: $colorPrimaryLight;
+  color: var(--colorSecondary);
 }
 
 @media only screen and (max-width: 1150px) {

--- a/assets/css/mailchimp.css
+++ b/assets/css/mailchimp.css
@@ -1,0 +1,80 @@
+$numpySlateGray: rgb(108, 122, 137);
+
+$colorPrimaryDark: rgb(1, 50, 67);
+$colorPrimaryLight: rgb(238, 238, 238); 
+
+.sign-up-container {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+  height: 75px;
+}
+
+.sign-up-image {
+  padding: 5px 10px 6px 10px;
+  border-right: 1px solid $colorPrimaryLight;
+  background-color: $colorPrimaryLight;
+  border-radius: 5px 0 0 5px;
+}
+
+.sign-up-input {
+  background-color: $colorPrimaryLight;
+  border-radius: 0 5px 5px 0;
+  border: none;
+  width: 75%;
+  height: 35px;
+  padding-left: 5px;
+  font-size: 14px;
+  color: $colorPrimaryDark;
+}
+
+.submission-instructions {
+  position: absolute;
+  right: 18%;
+  font-size: 10px;
+  color: $numpySlateGray;
+}
+
+.signup-button {
+  display: none;
+}
+
+.thank-you {
+  display: none;
+  height: 75px;
+  color: $colorPrimaryLight;
+  align-items: center;
+  color: $colorPrimaryLight;
+}
+
+@media only screen and (max-width: 1150px) {
+  .sign-up-input {
+    font-size: 12px;
+  }
+}
+
+@media only screen and (max-width: 850px) {
+  .sign-up-input {
+    width: 100%;
+  }
+
+  .thank-you {
+    justify-content: center;
+  }
+
+  .submission-instructions {
+    display: none;
+  }
+
+  .signup-button {
+    display: block;
+    height: 35px;
+    border-radius: 5px;
+    margin-left: 5px;
+    width: 60px;
+    color: black;
+    border:none;
+    outline:none;
+  }
+}


### PR DESCRIPTION
In https://github.com/scientific-python/scientific-python-hugo-theme/pull/48, @stefanv removed some styling for the numpy.org mailchimp signup box.  This updates the theme and adds the mailchimp box styling to numpy.org.

I want to double-check with @stefanv about whether I have to include these lines:
```
$colorPrimaryDark: rgb(1, 50, 67);
$colorPrimaryLight: rgb(238, 238, 238); 
```
or if I can access them from `theme/scientific-python-hugo-theme/assets/sass/styles.scss`.