### PR TITLE
Update info about NumPy teams

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -38,12 +38,13 @@ Emeritus:
 
 ## Teams
 
-The NumPy project is growing; we have teams for
+The NumPy project is growing! &#127881; We have teams for:
 
 - code
 - documentation
 - website
 - triage
+- survey
 - funding and grants
 
 See the [Team](/gallery/team.html) page for individual team members.

--- a/scripts/gallery/team.md
+++ b/scripts/gallery/team.md
@@ -114,4 +114,4 @@ We are an international team on a mission to support scientific and research com
 
 ### Governance
 
-For the list of people on the Steering Council, please see [here](https://numpy.org/devdocs/dev/governance/people.html)
+For the list of the Steering Council members, please see [here](https://numpy.org/about/).


### PR DESCRIPTION
1. Updating the link to the list of the Steering Council members on team.html 
Fixes #numpygh-503
2. Adding the survey team to the list of the existing NumPy teams on about.md
3. Making some very minor changes to the wording in the Teams section on about.md

