### PR TITLE
Add a link to the NumPy YouTube channel

### DIFF
--- a/content/en/contribute.md
+++ b/content/en/contribute.md
@@ -45,7 +45,9 @@ and welcoming environment.
 
 Programmers, this
 [guide](https://numpy.org/devdocs/dev/index.html#development-process-summary)
-explains how to contribute to the codebase.
+explains how to contribute to the NumPy codebase.
+<br>Check out also our [YouTube channel](https://www.youtube.com/playlist?list=PLCK6zCrcN3GXBUUzDr9L4__LnXZVtaIzS) for additional advice.
+
 
 ### Reviewing pull requests
 The project has more than 250 open pull requests -- meaning many potential


### PR DESCRIPTION
Add to contribute.md a link to the NumPy YouTube channel, specifically to the playlist titled "Contributing to NumPy: Getting Started".
Closes https://github.com/numpy/numpy.org/issues/533.