### PR TITLE
Use plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ To update the teams gallery in numpy.org site, you need to run `make teams` Make
 export GH_TOKEN=xxxxxxxxxx
 make teams
 ```
+
+## Analytics
+
+A self-hosted version of [Plausible.io](https://plausible.io) is used to gather simple
+and privacy-friendly analytics for the site. The dashboard can be accessed
+[here](https://views.scientific-python.org/numpy.org).

--- a/config.yaml.in
+++ b/config.yaml.in
@@ -21,6 +21,8 @@ params:
   font:
     name: "Lato"
     sizes: [400,900]
+  plausible:
+    dataDomain: numpy.org
 languages:
   en:
     title: NumPy


### PR DESCRIPTION
Trying plausible analytics.  We are using this for scipy.org, docs.scipy.org, and scientific-python.org.  If this PR is merged, you will be able to view the analytics for numpy.org at https://views.scientific-python.org/numpy.org.  The page is currently private, so you will need to create a plausible account and let @stefanv or me know what address you registered.

I don't know who currently has access to the google analytics, but we should make sure whoever is currently monitoring the google analytics is OK with using plausible.