### PR TITLE
Support google analytics

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+  <head>
+    {{ partial "meta.html" . }}
+    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+
+    <!-- Render theme css -->
+    {{ partial "css.html" . }}
+
+    <!-- Render custom header -->
+    {{ partial "head.html" . }}
+
+    <!-- Refer: https://regisphilibert.com/blog/2018/08/hugo-multilingual-part-1-managing-content-translation/ -->
+    {{ if .IsTranslated }}
+      {{ range .Translations }}
+      <link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .RelPermalink }}" title="{{ .Language.LanguageName }}" />
+      {{ end }}
+    {{ end }}
+    {{ template "_internal/twitter_cards.html" . }}
+  </head>
+  <body>
+    <!-- Preloader. Set to true for front-page fade-in animation -->
+    {{ if (and .IsHome .Site.Params.fadeFrontPage) }}
+    <div id="preloader"></div>
+    {{ end }}
+
+    {{ block "navbar" . }}
+    {{ partial "navbar.html" . }}
+    {{ partial "navbar-clone.html" . }}
+    {{ end }}
+
+    {{ block "main" . }}
+    {{ end }}
+
+    <!-- Back To Top Button -->
+    <div id="backtotop"><a href="#" id="backtotop-color"></a></div>
+
+    {{ if .Site.Params.footer }}
+    {{ partial "footer.html" . }}
+    {{ end }}
+
+    {{ partial "javascript.html" . }}
+    {{ template "_internal/google_analytics_async.html" . }}
+
+    {{ partial "analytics.html" . }}
+  </body>
+</html>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,0 +1,8 @@
+{{ template "_internal/google_analytics_async.html" . }}
+{{ if eq .Site.Params.openGraph true }}
+{{ template "_internal/opengraph.html" . }}
+{{ end }}
+<meta name="description" content="{{ if .Params.summary }}{{ .Params.summary }}{{ else if .Site.Params.Description }}{{ .Site.Params.Description }}{{ else }}Hardcoded description; the author should update :){{ end }}" />
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta http-equiv="x-ua-compatible" content="ie=edge">


### PR DESCRIPTION
Support for google analytics is no longer provided by the theme.  Since numpy.org will continue using google analytics (at least temporarily see #546), I am adding the old theme layout to the numpy.org repo.  If numpy.org decides to stop using google analytics, the following files
```
layouts/_default/baseof.html
layouts/partials/meta.html
```
should be deleted as well as this line
```
googleAnalytics: UA-162151853-1
```
in `config.yaml.in`.