### PR TITLE
Switch to the upstream JupyterLite REPL app

### DIFF
--- a/assets/css/shell.css
+++ b/assets/css/shell.css
@@ -48,28 +48,6 @@
     font-weight: bold;
 }
 
-.shell-enable-button {
-    position: relative;
-    margin: 15px 0;
-}
-
-.shell-button {
-    width: 225px;
-    height: 50px;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    font-weight: 500;
-    color: rgb(0,0,0);
-    background-color: rgb(238, 238, 238);
-    border: none;
-    border-radius: 25px;
-    outline: none;
-    /* Black, with 10% opacity */
-    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-    cursor: pointer;
-}
-
 .shell-lesson {
     display: flex;
     text-align: left;

--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -21,14 +21,9 @@ params:
 
     intro:
     - title: Try NumPy
-      text: Enable the interactive shell
+      text: Use the interactive shell to try NumPy in the browser
 
     docslink: Don't forget to check out the <a href="https://numpy.org/doc/stable" target="_blank">docs</a>.
-
-    button:
-    - label: Enables the interactive tutorial shell
-      text: Enable
-
 
   casestudies:
     title: CASE STUDIES

--- a/content/ja/config.yaml
+++ b/content/ja/config.yaml
@@ -30,14 +30,9 @@ params:
 
     intro:
     - title: Try NumPy
-      text: Enable the interactive shell
+      text: Use the interactive shell to try NumPy in the browser
 
     docslink: Don't forget to check out the <a href="https://numpy.org/doc/stable" target="_blank">docs</a>.
-
-    button:
-    - label: Enables the interactive tutorial shell
-      text: Enable
-
 
   casestudies:
     title: ケーススタディ

--- a/content/pt/config.yaml
+++ b/content/pt/config.yaml
@@ -30,14 +30,9 @@ params:
 
     intro:
     - title: Try NumPy
-      text: Enable the interactive shell
+      text: Use the interactive shell to try NumPy in the browser
 
     docslink: Don't forget to check out the <a href="https://numpy.org/doc/stable" target="_blank">docs</a>.
-
-    button:
-    - label: Enables the interactive tutorial shell
-      text: Enable
-
 
   casestudies:
     title: ESTUDOS DE CASO

--- a/layouts/partials/shell.html
+++ b/layouts/partials/shell.html
@@ -1,5 +1,4 @@
 {{- $shell := .Site.Params.shell }}
-{{- $button := index $shell "button" }}
 {{- $intro := index $shell "intro" }}
 <div class="hero-right">
     <div class="flex-column shell-title-container">
@@ -16,15 +15,9 @@
                 {{partial "shell-lesson.html" | print | markdownify}}
             </div>
             <!-- Interactive Shell -->
-            {{- range $button }}
-            <button class="shell-enable-button shell-button" onclick="loadShell();" aria-label="{{ .label }}">
-                {{ .text }}
-            </button>
-            {{- end }}
             <iframe
                 id="numpy-shell"
-                style="display: none"
-                src="https://replite.vercel.app/retro/consoles/?toolbar=1&kernel=python&code=import%20numpy%20as%20np"
+                src="https:/jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=import%20numpy%20as%20np"
                 width="100%"
                 height="100%"
             >

--- a/layouts/partials/shell.html
+++ b/layouts/partials/shell.html
@@ -17,7 +17,7 @@
             <!-- Interactive Shell -->
             <iframe
                 id="numpy-shell"
-                src="https:/jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=import%20numpy%20as%20np"
+                src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=import%20numpy%20as%20np"
                 width="100%"
                 height="100%"
             >

--- a/static/css/shell.css
+++ b/static/css/shell.css
@@ -47,28 +47,6 @@
     font-weight: bold;
 }
 
-.shell-enable-button {
-    position: relative;
-    margin: 15px 0;
-}
-
-.shell-button {
-    width: 225px;
-    height: 50px;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    font-weight: 500;
-    color: rgb(0,0,0);
-    background-color: rgb(238, 238, 238);
-    border: none;
-    border-radius: 25px;
-    outline: none;
-    /* Black, with 10% opacity */
-    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-    cursor: pointer;
-}
-
 .shell-lesson {
     display: none;
     text-align: left;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -9,11 +9,6 @@ $('.sign-up-input').focus(function(e) {
   }
 });
 
-function loadShell() {
-  $('.shell-enable-button').remove();
-  $('#numpy-shell').css('display', 'flex');
-}
-
 function sendThankYou() {
   // Hides the email form to show a thank you
   $('.sign-up-container').css('display', 'none');


### PR DESCRIPTION
#### Brief description of what is fixed or changed

Follow-up to #547 and #556 

JupyterLite now ships with the `repl` app by default:

- Added in: https://github.com/jupyterlite/jupyterlite/pull/498
- Documentation: https://jupyterlite.readthedocs.io/en/latest/applications/repl.html
- Changelog: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0a23

This PR updates the "Try NumPy" section:

- [x] The URL of the interactive code console now points to the JupyterLite demo repo: https:/jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=import%20numpy%20as%20np
- [x] Remove the "Enable" button, since updating to the upstream code console also fixes the scrolling issue initially reported in https://github.com/numpy/numpy.org/pull/547#issuecomment-1028686114
- [x] Clean up unused styles


https://user-images.githubusercontent.com/591645/154056572-4675b611-00c0-4488-b8b7-99d2ece07215.mp4



---

A follow-up to this would be to start making a custom JupyterLite deployment that can then be hosted in the `numpy` GitHub organization, for example at https://github.com/numpy/try or https://github.com/numpy/jupyterlite-repl.

The custom deployment can easily be done using this template repo: https://github.com/jupyterlite/demo