### PR TITLE
Improve JupyterLite console alignment

### DIFF
--- a/assets/css/shell.css
+++ b/assets/css/shell.css
@@ -1,40 +1,27 @@
 .hero-right {
     display: flex;
     flex-direction: column;
-    width: 100vw;
     /* Black, with 10% opacity */
     box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
 }
 
 .numpy-shell-canvas {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100vw;
     min-height: 455px;
     background-color: rgb(238, 238, 238);
 }
 
 .numpy-shell-container {
-    width: 100vw;
-    max-width: 1200px;
     height: 100%;
-    min-height: 400px;
     display: flex;
     position: relative;
     flex-direction: row;
     justify-content: space-evenly;
-    align-items: center;
+    align-items: stretch;
 }
 
-.shell-content {
-    display: flex;
-    flex-direction: column;
-    text-align: center;
-}
-
-#numpy-shell {
-    min-height: 600px;
+.numpy-shell {
+    flex: 2;
+    padding: 0 15px;
 }
 
 .shell-title-container {
@@ -49,9 +36,16 @@
 }
 
 .shell-lesson {
-    display: flex;
     text-align: left;
-    padding: 15px;
+    flex: 1;
+    padding: 0 15px;
+}
+
+.shell-lesson .highlight {
+    height: 100%;
+}
+
+.shell-lesson .highlight pre {
     height: 100%;
 }
 
@@ -80,13 +74,13 @@
     border-left: 1px solid white !important;
 }
 
-@media only screen and (max-width: 1090px) {
+@media only screen and (max-width: 800px) {
     .numpy-shell-container {
         flex-direction: column;
         justify-content: space-around;
     }
 
-    #numpy-shell {
+    .numpy-shell {
         min-height: 500px;
     }
 }

--- a/assets/css/shell.css
+++ b/assets/css/shell.css
@@ -4,6 +4,7 @@
     /* Black, with 10% opacity */
     box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
     background: rgb(238, 238, 238);
+    padding: 15px;
 }
 
 .numpy-shell-canvas {

--- a/assets/css/shell.css
+++ b/assets/css/shell.css
@@ -3,11 +3,11 @@
     flex-direction: column;
     /* Black, with 10% opacity */
     box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
+    background: rgb(238, 238, 238);
 }
 
 .numpy-shell-canvas {
     min-height: 455px;
-    background-color: rgb(238, 238, 238);
 }
 
 .numpy-shell-container {
@@ -17,6 +17,8 @@
     flex-direction: row;
     justify-content: space-evenly;
     align-items: stretch;
+    max-width: 1500px;
+    margin: auto;
 }
 
 .numpy-shell {
@@ -27,7 +29,6 @@
 .shell-title-container {
     text-align: center;
     align-items: center;
-    background: rgb(238, 238, 238);
 }
 
 .shell-title {

--- a/layouts/partials/shell.html
+++ b/layouts/partials/shell.html
@@ -16,10 +16,8 @@
             </div>
             <!-- Interactive Shell -->
             <iframe
-                id="numpy-shell"
+                class="numpy-shell"
                 src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&code=import%20numpy%20as%20np"
-                width="100%"
-                height="100%"
             >
             </iframe>
         </div>


### PR DESCRIPTION
This improves the alignment of the code console with respect to the example snipet

**Before:**

![before](https://user-images.githubusercontent.com/2397974/158599179-d1767dd1-5e0f-4227-8921-1d9299adf2d8.png)

**After:**

![after](https://user-images.githubusercontent.com/2397974/158600016-aa67b295-3065-4dbf-ae72-46d78f036ec4.png)