### PR TITLE
Fix link to SciPy Code of Conduct in Numpy Code of Conduct

### DIFF
--- a/content/en/code-of-conduct.md
+++ b/content/en/code-of-conduct.md
@@ -80,4 +80,4 @@ The Committee will respond to any report as soon as possible, and at most within
 
 We are thankful to the groups behind the following documents, from which we drew content and inspiration:
 
-- [The SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html)
+- [The SciPy Code of Conduct](https://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html)

--- a/content/en/code-of-conduct.md
+++ b/content/en/code-of-conduct.md
@@ -80,4 +80,4 @@ The Committee will respond to any report as soon as possible, and at most within
 
 We are thankful to the groups behind the following documents, from which we drew content and inspiration:
 
-- [The SciPy Code of Conduct](https://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html)
+- [The SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html)


### PR DESCRIPTION

Fixes gh-595

Using the link provided on the SciPy Community page: 
https://scipy.org/community/

