### PR TITLE
Updated link colors to NumPy Deep Blue #497

### DIFF
--- a/assets/css/vars-override.css
+++ b/assets/css/vars-override.css
@@ -1,0 +1,3 @@
+:root {
+    --colorContentLink: rgb(77, 119, 207);
+}


### PR DESCRIPTION

#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->
Fixes gh-497

Many links were colored #1e87f0 - updated them to match the Numpy color palette by coloring them #4D77CF (Numpy Deep Blue)

