### PR TITLE
DOC: Update ordering details and some translations

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -18,10 +18,10 @@ The role of the NumPy Steering Council is to ensure, through working with and se
 - Ralf Gommers
 - Charles Harris
 - Stephan Hoyer
-- Melissa Weber Mendonça
 - Inessa Pawson
 - Matti Picus
 - Stéfan van der Walt
+- Melissa Weber Mendonça
 - Eric Wieser
 
 Emeritus:

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -14,26 +14,26 @@ NumPy is developed in the open on GitHub, through the consensus of the NumPy and
 
 The role of the NumPy Steering Council is to ensure, through working with and serving the broader NumPy community, the long-term well-being of the project, both technically and as a community. The NumPy Steering Council currently consists of the following members (in alphabetical order):
 
-- Sebastian Berg
-- Ralf Gommers
 - Charles Harris
-- Stephan Hoyer
-- Melissa Weber Mendonça
+- Eric Wieser
 - Inessa Pawson
 - Matti Picus
+- Melissa Weber Mendonça
+- Ralf Gommers
+- Sebastian Berg
+- Stephan Hoyer
 - Stéfan van der Walt
-- Eric Wieser
 
 Emeritus:
 
-- Travis Oliphant (project founder, 2005-2012)
 - Alex Griffing (2015-2017)
-- Marten van Kerkwijk (2017-2019)
 - Allan Haldane (2015-2021)
-- Nathaniel Smith (2012-2021)
-- Julian Taylor (2013-2021)
-- Pauli Virtanen (2008-2021)
 - Jaime Fernández del Río (2014-2021)
+- Julian Taylor (2013-2021)
+- Marten van Kerkwijk (2017-2019)
+- Nathaniel Smith (2012-2021)
+- Pauli Virtanen (2008-2021)
+- Travis Oliphant (project founder, 2005-2012)
 
 
 ## Teams
@@ -52,8 +52,8 @@ See the [Team]({{< relref "/teams" >}}) page for individual team members.
 ## NumFOCUS Subcommittee
 
 - Charles Harris
-- Ralf Gommers
 - Melissa Weber Mendonça
+- Ralf Gommers
 - Sebastian Berg
 - External member: Thomas Caswell
 

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -12,28 +12,28 @@ NumPy is developed in the open on GitHub, through the consensus of the NumPy and
 
 ## Steering Council
 
-The role of the NumPy Steering Council is to ensure, through working with and serving the broader NumPy community, the long-term well-being of the project, both technically and as a community. The NumPy Steering Council currently consists of the following members (in alphabetical order):
+The role of the NumPy Steering Council is to ensure, through working with and serving the broader NumPy community, the long-term well-being of the project, both technically and as a community. The NumPy Steering Council currently consists of the following members (in alphabetical order, by last name):
 
+- Sebastian Berg
+- Ralf Gommers
 - Charles Harris
-- Eric Wieser
+- Stephan Hoyer
+- Melissa Weber Mendonça
 - Inessa Pawson
 - Matti Picus
-- Melissa Weber Mendonça
-- Ralf Gommers
-- Sebastian Berg
-- Stephan Hoyer
 - Stéfan van der Walt
+- Eric Wieser
 
 Emeritus:
 
 - Alex Griffing (2015-2017)
 - Allan Haldane (2015-2021)
-- Jaime Fernández del Río (2014-2021)
-- Julian Taylor (2013-2021)
 - Marten van Kerkwijk (2017-2019)
-- Nathaniel Smith (2012-2021)
-- Pauli Virtanen (2008-2021)
 - Travis Oliphant (project founder, 2005-2012)
+- Nathaniel Smith (2012-2021)
+- Julian Taylor (2013-2021)
+- Jaime Fernández del Río (2014-2021)
+- Pauli Virtanen (2008-2021)
 
 
 ## Teams
@@ -52,8 +52,8 @@ See the [Team]({{< relref "/teams" >}}) page for individual team members.
 ## NumFOCUS Subcommittee
 
 - Charles Harris
-- Melissa Weber Mendonça
 - Ralf Gommers
+- Melissa Weber Mendonça
 - Sebastian Berg
 - External member: Thomas Caswell
 

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -14,24 +14,26 @@ NumPy は 、NumPyコミュニティやより広範な科学計算用Python コ�
 
 NumPy運営委員会の役割は、NumPyのコミュニティと協力しサポートすることを通じて、技術的にもコミュニティ的にも長期的にNumPyプロジェクトを良い状態に保つことです。 NumPy運営委員会は現在以下のメンバーで構成されています (アルファベット順):
 
-- Sebastian Berg
-- Jaime Fernández del Río
-- Ralf Gommers
-- Allan Haldane
 - Charles Harris
-- Stephan Hoyer
-- Matti Picus
-- Nathaniel Smith
-- Julian Taylor
-- Pauli Virtanen
-- Stéfan van der Walt
 - Eric Wieser
+- Inessa Pawson
+- Matti Picus
+- Melissa Weber Mendonça
+- Ralf Gommers
+- Sebastian Berg
+- Stephan Hoyer
+- Stéfan van der Walt
 
 終身名誉委員
 
-- Travis Oliphant (プロジェクト創設者, 2005-2012)
 - Alex Griffing (2015-2017)
+- Allan Haldane (2015-2021)
+- Jaime Fernández del Río (2014-2021)
+- Julian Taylor (2013-2021)
 - Marten van Kerkwijk (2017-2019)
+- Nathaniel Smith (2012-2021)
+- Pauli Virtanen (2008-2021)
+- Travis Oliphant (プロジェクト創設者, 2005-2012)
 
 ## チーム
 

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -18,10 +18,10 @@ NumPy運営委員会の役割は、NumPyのコミュニティと協力しサポ�
 - Ralf Gommers
 - Charles Harris
 - Stephan Hoyer
-- Melissa Weber Mendonça
 - Inessa Pawson
 - Matti Picus
 - Stéfan van der Walt
+- Melissa Weber Mendonça
 - Eric Wieser
 
 終身名誉委員

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -12,28 +12,28 @@ NumPy は 、NumPyコミュニティやより広範な科学計算用Python コ�
 
 ## 運営委員会
 
-NumPy運営委員会の役割は、NumPyのコミュニティと協力しサポートすることを通じて、技術的にもコミュニティ的にも長期的にNumPyプロジェクトを良い状態に保つことです。 NumPy運営委員会は現在以下のメンバーで構成されています (アルファベット順):
+NumPy運営委員会の役割は、NumPyのコミュニティと協力しサポートすることを通じて、技術的にもコミュニティ的にも長期的にNumPyプロジェクトを良い状態に保つことです。 NumPy運営委員会は現在以下のメンバーで構成されています (アルファベット順、姓で):
 
+- Sebastian Berg
+- Ralf Gommers
 - Charles Harris
-- Eric Wieser
+- Stephan Hoyer
+- Melissa Weber Mendonça
 - Inessa Pawson
 - Matti Picus
-- Melissa Weber Mendonça
-- Ralf Gommers
-- Sebastian Berg
-- Stephan Hoyer
 - Stéfan van der Walt
+- Eric Wieser
 
 終身名誉委員
 
 - Alex Griffing (2015-2017)
 - Allan Haldane (2015-2021)
-- Jaime Fernández del Río (2014-2021)
-- Julian Taylor (2013-2021)
 - Marten van Kerkwijk (2017-2019)
+- Travis Oliphant (project founder, 2005-2012)
 - Nathaniel Smith (2012-2021)
+- Julian Taylor (2013-2021)
+- Jaime Fernández del Río (2014-2021)
 - Pauli Virtanen (2008-2021)
-- Travis Oliphant (プロジェクト創設者, 2005-2012)
 
 ## チーム
 

--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -18,10 +18,10 @@ O papel do Conselho Diretor do NumPy consiste em assegurar o bem-estar a longo p
 - Ralf Gommers
 - Charles Harris
 - Stephan Hoyer
-- Melissa Weber Mendonça
 - Inessa Pawson
 - Matti Picus
 - Stéfan van der Walt
+- Melissa Weber Mendonça
 - Eric Wieser
 
 Membros Eméritos:

--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -14,24 +14,26 @@ O NumPy é desenvolvido no GitHub, através do consenso da comunidade NumPy e de
 
 O papel do Conselho Diretor do NumPy consiste em assegurar o bem-estar a longo prazo do projeto, tanto nos aspectos técnicos quanto na comunidade. Isso é feito através do trabalho com e para a comunidade NumPy em geral. O Conselho Diretor do NumPy atualmente consiste dos seguintes membros (em ordem alfabética):
 
-- Sebastian Berg
-- Jaime Fernández del Río
-- Ralf Gommers
-- Allan Haldane
 - Charles Harris
-- Stephan Hoyer
-- Matti Picus
-- Nathaniel Smith
-- Julian Taylor
-- Pauli Virtanen
-- Stéfan van der Walt
 - Eric Wieser
+- Inessa Pawson
+- Matti Picus
+- Melissa Weber Mendonça
+- Ralf Gommers
+- Sebastian Berg
+- Stephan Hoyer
+- Stéfan van der Walt
 
 Membros Eméritos:
 
-- Travis Oliphant (fundador do projeto, 2005-2012)
 - Alex Griffing (2015-2017)
+- Allan Haldane (2015-2021)
+- Jaime Fernández del Río (2014-2021)
+- Julian Taylor (2013-2021)
 - Marten van Kerkwijk (2017-2019)
+- Nathaniel Smith (2012-2021)
+- Pauli Virtanen (2008-2021)
+- Travis Oliphant (fundador do projeto, 2005-2012)
 
 ## Times
 

--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -12,28 +12,28 @@ O NumPy é desenvolvido no GitHub, através do consenso da comunidade NumPy e de
 
 ## Conselho Diretor (Steering Council)
 
-O papel do Conselho Diretor do NumPy consiste em assegurar o bem-estar a longo prazo do projeto, tanto nos aspectos técnicos quanto na comunidade. Isso é feito através do trabalho com e para a comunidade NumPy em geral. O Conselho Diretor do NumPy atualmente consiste dos seguintes membros (em ordem alfabética):
+O papel do Conselho Diretor do NumPy consiste em assegurar o bem-estar a longo prazo do projeto, tanto nos aspectos técnicos quanto na comunidade. Isso é feito através do trabalho com e para a comunidade NumPy em geral. O Conselho Diretor do NumPy atualmente consiste dos seguintes membros (em ordem alfabética, pelo sobrenome):
 
+- Sebastian Berg
+- Ralf Gommers
 - Charles Harris
-- Eric Wieser
+- Stephan Hoyer
+- Melissa Weber Mendonça
 - Inessa Pawson
 - Matti Picus
-- Melissa Weber Mendonça
-- Ralf Gommers
-- Sebastian Berg
-- Stephan Hoyer
 - Stéfan van der Walt
+- Eric Wieser
 
 Membros Eméritos:
 
 - Alex Griffing (2015-2017)
 - Allan Haldane (2015-2021)
-- Jaime Fernández del Río (2014-2021)
-- Julian Taylor (2013-2021)
 - Marten van Kerkwijk (2017-2019)
+- Travis Oliphant (project founder, 2005-2012)
 - Nathaniel Smith (2012-2021)
+- Julian Taylor (2013-2021)
+- Jaime Fernández del Río (2014-2021)
 - Pauli Virtanen (2008-2021)
-- Travis Oliphant (fundador do projeto, 2005-2012)
 
 ## Times
 


### PR DESCRIPTION
#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->
~- Updated the order of names in the `en/about` page to be in alphabetical order (as promised by the page)~
- Clarified the ordering of names
- Updated the names and order of `{ja,pt}/about` pages
