### PR TITLE
Align images for multiline titles in CS section

### DIFF
--- a/assets/css/casestudies.css
+++ b/assets/css/casestudies.css
@@ -38,6 +38,12 @@
     text-transform: uppercase;
 }
 
+.casestudies-box-content img {
+    object-fit: cover;
+    width: 350px;
+    height: 218.5px;
+}
+
 .casestudies-box-text {
     margin: 30px 15px;
     font-size: 14px;

--- a/assets/css/casestudies.css
+++ b/assets/css/casestudies.css
@@ -47,7 +47,7 @@
 }
 
 .casestudies-box-text {
-    margin: 30px 15px auto 15px;
+    margin: 30px 15px;
     font-size: 14px;
 }
 

--- a/assets/css/casestudies.css
+++ b/assets/css/casestudies.css
@@ -33,6 +33,8 @@
 }
 
 .casestudies-box-title {
+    line-height: 1.5em;
+    height: 3.0em;
     margin: 15px;
     font-size: 16px;
     text-transform: uppercase;
@@ -45,7 +47,7 @@
 }
 
 .casestudies-box-text {
-    margin: 30px 15px;
+    margin: 30px 15px auto 15px;
     font-size: 14px;
 }
 

--- a/layouts/partials/casestudies.html
+++ b/layouts/partials/casestudies.html
@@ -8,7 +8,7 @@
             {{- range $features }}
             <a class="casestudies-box-content casestudies-underline" href="{{ .url }}">
                 <div class="casestudies-box-title">{{ .title }}</div>
-                    <img src="{{ .img }}" alt="{{ .alttext }}">
+                <img src="{{ .img }}" alt="{{ .alttext }}">
                 <div class="casestudies-box-text">{{ .text | markdownify }}</div>
             </a>
             {{- end }}


### PR DESCRIPTION
Fixes gh-416

1. Set images width and height to be the same. The `static/images/content_images/case_studies/deeplabcut.png` has different aspect ratio than the rest, which resulted in misalignment with other cards in 2x2 grid.
2. Set title height to be the double of line height. This guarantees alignment of all images in case of titles with two lines.


A note on point 2: A more interesting approach could be to check the number of lines of the longest title and set the line height of all titles to the line height of that one. I tried this but couldn't make the height of the card to update accordingly.