### PR TITLE
Added Community Calendar link under Community section

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -74,3 +74,4 @@ To thrive, the NumPy project needs your expertise and enthusiasm. Not a coder? N
 
 If you are interested in becoming a NumPy contributor (yay!) we recommend checking out our [Contribute](/contribute) page.
 
+NumPy also has a [Community Calendar](https://scientific-python.org/calendars/) that lists all upcoming NumPy community events. 

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -74,4 +74,4 @@ To thrive, the NumPy project needs your expertise and enthusiasm. Not a coder? N
 
 If you are interested in becoming a NumPy contributor (yay!) we recommend checking out our [Contribute](/contribute) page.
 
-NumPy also has a [Community Calendar](https://scientific-python.org/calendars/) that lists all upcoming NumPy community events. 
+Also, feel free to stop by and say hi at one of our community meetings. To keep track of them, check out our events calendar [here](https://scientific-python.org/calendars/).


### PR DESCRIPTION
Fix: https://github.com/numpy/numpy.org/issues/436

Description:
The Community Calendar link which can be used to track all upcoming NumPy events is added to the Community section of the website.
