### PR TITLE
Standard size of logos in array libraries tab

### DIFF
--- a/assets/css/tabs.css
+++ b/assets/css/tabs.css
@@ -143,7 +143,9 @@ td.lastrow-center-text {
 
 /* Array Libraries */
 img.first-column-layout {
-    height: 30px;
+    max-width: 100px;
+    max-height: 30px;
+    margin: 0px 20px 0px 10px;
 }
 
 td.left-text {

--- a/layouts/partials/array-libraries.html
+++ b/layouts/partials/array-libraries.html
@@ -19,7 +19,7 @@
         </tr>
         {{- range $libraries }}
         <tr>
-            <td><img class="first-column-layout" src="{{ .img }}" alt="{{ .alttext }}"></td>
+            <td style="text-align: center"><img class="first-column-layout" src="{{ .img }}" alt="{{ .alttext }}"></td>
             <td class="full-center-text"><a href="{{ .url }}">{{ .title }}</a></td>
             <td class="left-text">{{ .text }}</td>
         </tr>


### PR DESCRIPTION
Fixes [gh-489](https://github.com/numpy/numpy.org/issues/489#issue-1036065739)

The logos on the array libraries tab have different sizes, here they have a standard size (that might be changed, for example if reduced logos would be even more uniform).

Before:
![image](https://user-images.githubusercontent.com/74407966/216793787-750c6bfc-9d1e-42c7-90b6-1ebef34fc473.png)
After:
![image](https://user-images.githubusercontent.com/74407966/216793804-2621fc27-c32e-41d7-9676-0d793dc975f8.png)


