### PR TITLE
Move the 'Open Source' key feature

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -56,8 +56,7 @@ params:
     - title: Numerical computing tools
       text: NumPy offers comprehensive mathematical functions, random number generators, linear algebra routines, Fourier transforms, and more.
     - title: Open source
-      text: Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt), NumPy is developed and 
-      maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
+      text: Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt), NumPy is developed and maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
     - title: Interoperable
       text: NumPy supports a wide range of hardware and computing platforms, and plays well with distributed, GPU, and sparse array libraries.
     - title: Performant

--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -55,14 +55,16 @@ params:
       text:  Fast and versatile, the NumPy vectorization, indexing, and broadcasting concepts are the de-facto standards of array computing today.
     - title: Numerical computing tools
       text: NumPy offers comprehensive mathematical functions, random number generators, linear algebra routines, Fourier transforms, and more.
+    - title: Open source
+      text: Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt), NumPy is developed and 
+      maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
     - title: Interoperable
       text: NumPy supports a wide range of hardware and computing platforms, and plays well with distributed, GPU, and sparse array libraries.
     - title: Performant
       text: The core of NumPy is well-optimized C code. Enjoy the flexibility of Python with the speed of compiled code.
     - title: Easy to use
       text: NumPy's high level syntax makes it accessible and productive for programmers from any background or experience level.
-    - title: Open source
-      text: Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt), NumPy is developed and maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
+    
   tabs:
     title: ECOSYSTEM
   section5: false


### PR DESCRIPTION
Move the 'Open Source' key feature to a more visible place on the homepage.