### PR TITLE
Add the latest release info to the homepage

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -10,9 +10,9 @@ params:
     # Hero subtitle (optional)
     subtitle: The fundamental package for scientific computing with Python
     # Button text
-    buttontext: Get started
+    buttontext: Latest release: numpy 1.24.2. View all releases.
     # Where the main hero button links to
-    buttonlink: "/install"
+    buttonlink: "/news/#releases"
     # Hero image (from static/images/___)
     image: logo.svg
 

--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -10,7 +10,7 @@ params:
     # Hero subtitle (optional)
     subtitle: The fundamental package for scientific computing with Python
     # Button text
-    buttontext: Latest release: numpy 1.24.2. View all releases.
+    buttontext: "Latest release: numpy 1.24.2. View all releases."
     # Where the main hero button links to
     buttonlink: "/news/#releases"
     # Hero image (from static/images/___)


### PR DESCRIPTION
I propose this UI change based on the discussion at the 2023-02-15 community call. See the meeting notes here: https://github.com/numpy/archive/blob/main/community_meetings/community-2023-02-15.md.