### PR TITLE
Add the email address for the NumPy Steering Council

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -35,6 +35,7 @@ Emeritus:
 - Jaime Fernández del Río (2014-2021)
 - Pauli Virtanen (2008-2021)
 
+To contact the NumPy Steering Council, please email at numpy-steering-council@googlegroups.com.
 
 ## Teams
 


### PR DESCRIPTION
Adding the email address for the NumPy Steering Council.
Addresses https://github.com/numpy/numpy.org/issues/631.
