### PR TITLE
Update info about the current NumPy teams and institutional partners

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -39,7 +39,7 @@ Emeritus:
 The NumPy project leadership is actively working on diversifying contribution pathways to the project.<br>
 NumPy currently has the following teams:
 
-- developer
+- development
 - documentation
 - triage
 - website

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -68,7 +68,6 @@ NumPy receives direct funding from the following sources:
 
 Institutional Partners are organizations that support the project by employing people that contribute to NumPy as part of their job. Current Institutional Partners include:
 
-- UC Berkeley (Stéfan van der Walt)
 - Quansight (Nathan Goldbaum, Ralf Gommers, Matti Picus, Melissa Weber Mendonça)
 - NVIDIA (Sebastian Berg)
 

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -68,6 +68,7 @@ NumPy receives direct funding from the following sources:
 
 Institutional Partners are organizations that support the project by employing people that contribute to NumPy as part of their job. Current Institutional Partners include:
 
+- UC Berkeley (Stéfan van der Walt)
 - Quansight (Nathan Goldbaum, Ralf Gommers, Matti Picus, Melissa Weber Mendonça)
 - NVIDIA (Sebastian Berg)
 

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -3,16 +3,14 @@ title: About Us
 sidebar: false
 ---
 
-_Some information about the NumPy project and community_
-
-NumPy is an open source project aiming to enable numerical computing with Python. It was created in 2005, building on the early work of the Numeric and Numarray libraries. NumPy will always be 100% open source software, free for all to use and released under the liberal terms of the [modified BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt).
+NumPy is an open source project that enables numerical computing with Python. It was created in 2005 building on the early work of the Numeric and Numarray libraries. NumPy will always be 100% open source software and free for all to use. It is released under the liberal terms of the [modified BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt).
 
 NumPy is developed in the open on GitHub, through the consensus of the NumPy and wider scientific Python community. For more information on our governance approach, please see our [Governance Document](https://www.numpy.org/devdocs/dev/governance/index.html).
 
 
 ## Steering Council
 
-The role of the NumPy Steering Council is to ensure, through working with and serving the broader NumPy community, the long-term well-being of the project, both technically and as a community. The NumPy Steering Council currently consists of the following members (in alphabetical order, by last name):
+The NumPy Steering Council is the project's governing body. Its role is to ensure, through working with and serving the broader NumPy community, the long-term sustainability of the project, both as a software package and community. The NumPy Steering Council currently consists of the following members (in alphabetical order, by last name):
 
 - Sebastian Berg
 - Ralf Gommers
@@ -38,16 +36,19 @@ Emeritus:
 
 ## Teams
 
-The NumPy project is growing! &#127881; We have teams for:
+The NumPy project leadership is actively working on diversifying contribution pathways to the project.<br>
+NumPy currently has the following teams:
 
-- code
+- developer
 - documentation
-- website
 - triage
+- website
 - survey
+- translations
+- sprint mentors
 - funding and grants
 
-See the [Team]({{< relref "/teams" >}}) page for individual team members.
+See the [Team]({{< relref "/teams" >}}) page for more info.
 
 ## NumFOCUS Subcommittee
 
@@ -67,8 +68,8 @@ NumPy receives direct funding from the following sources:
 
 Institutional Partners are organizations that support the project by employing people that contribute to NumPy as part of their job. Current Institutional Partners include:
 
-- UC Berkeley (Stéfan van der Walt, Ross Barnowski)
-- Quansight (Ralf Gommers, Melissa Weber Mendonça, Mars Lee, Matti Picus, Pearu Peterson)
+- UC Berkeley (Stéfan van der Walt)
+- Quansight (Nathan Goldbaum, Ralf Gommers, Matti Picus, Melissa Weber Mendonça)
 - NVIDIA (Sebastian Berg)
 
 {{< partners >}}


### PR DESCRIPTION
- Update info about the current NumPy teams and institutional partners.
- Rephrase for clarity some parts of the text.
