### PR TITLE
Announce NumPy 1.25 on homepage

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -10,7 +10,7 @@ params:
     # Hero subtitle (optional)
     subtitle: The fundamental package for scientific computing with Python
     # Button text
-    buttontext: "Latest release: NumPy 1.25. View all releases."
+    buttontext: "Latest release: NumPy 1.25. View all releases"
     # Where the main hero button links to
     buttonlink: "/news/#releases"
     # Hero image (from static/images/___)

--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -10,7 +10,7 @@ params:
     # Hero subtitle (optional)
     subtitle: The fundamental package for scientific computing with Python
     # Button text
-    buttontext: "Latest release: numpy 1.24.2. View all releases."
+    buttontext: "Latest release: NumPy 1.25. View all releases."
     # Where the main hero button links to
     buttonlink: "/news/#releases"
     # Hero image (from static/images/___)

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -8,12 +8,12 @@ date: 2023-06-17
 ### NumPy 1.25.0 released
 
 _Jun 17, 2023_ -- [NumPy 1.25.0](https://numpy.org/doc/stable/release/1.25.0-notes.html)
-is now available. Some highlights are:
+is now available. The highlights of the release are:
 
 * Support for MUSL, there are now MUSL wheels.
-* Support the Fujitsu C/C++ compiler.
-* Object arrays are now supported in einsum
-* Support for inplace matrix multiplication (``@=``).
+* Support for the Fujitsu C/C++ compiler.
+* Object arrays are now supported in einsum.
+* Support for the inplace matrix multiplication (``@=``).
 
 The NumPy 1.25.0 release continues the ongoing work to improve the handling and
 promotion of dtypes, increase the execution speed, and clarify the
@@ -21,7 +21,9 @@ documentation. There has also been preparatory work for the future NumPy 2.0.0,
 resulting in a large number of new and expired deprecations.
 
 A total of 148 people contributed to this release and 530 pull requests were
-merged.  The Python versions supported are 3.9-3.11.
+merged. 
+
+The Python versions supported by this release are 3.9-3.11.
 
 ### Fostering an Inclusive Culture: Call for Participation
 


### PR DESCRIPTION
1. Announce NumPy 1.25 on homepage.
2. Minor fixes in the news article about the release.

