### PR TITLE
Make internal link work for translated content

### DIFF
--- a/content/en/install.md
+++ b/content/en/install.md
@@ -129,6 +129,7 @@ The third difference is that conda is an integrated solution for managing
 packages, dependencies and environments, while with pip you may need another
 tool (there are many!) for dealing with environments or complex dependencies.
 
+<a name="reproducible-installs"></a>
 
 ### Reproducible installs
 


### PR DESCRIPTION
This PR adds an anchor before the **Reproducible installs** heading in `install.md`. This will allow the internal link to this section work for translated content.

See https://github.com/numpy/numpy.org/issues/55#issuecomment-1599175991

Previously, anchors were added just to the translated content in gh-540, but when translations need to be updated, these will be stripped by Crowdin if the anchor does not appear in the English content.