### PR TITLE
Add translations for new numpy release line in news.md

### DIFF
--- a/content/ja/news.md
+++ b/content/ja/news.md
@@ -186,6 +186,7 @@ _2019年11月15日_ -- NumPyと、NumPyの重要な依存ライブラリの1つ�
 
 こちらは、より以前のNumPyリリースのリストで、各リリースノートへのリンクが記載されています。 全てのバグフィックスリリース(バージョン番号`x.y.z` の`z`だけが変更されたもの)は新しい機能追加はされず、マイナーリリース (`y` が増えたもの)は、新しい機能追加されています。
 
+- NumPy 1.25.2 ([リリースノート](https://github.com/numpy/numpy/releases/tag/v1.25.2)) -- _2023年7月31日_.
 - NumPy 1.25.1 ([リリースノート](https://github.com/numpy/numpy/releases/tag/v1.25.1)) -- _2023年7月8日_.
 - NumPy 1.24.4 ([リリースノート](https://github.com/numpy/numpy/releases/tag/v1.24.4)) -- _2023年6月26日_.
 - NumPy 1.25.0 ([リリースノート](https://github.com/numpy/numpy/releases/tag/v1.25.0)) -- _2023年6月17日_.

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -186,8 +186,9 @@ Mais detalhes sobre nossas propostas e resultados esperados podem ser encontrado
 
 Aqui está uma lista de versões do NumPy, com links para notas de lançamento. Bugfix lança (apenas o `z` muda no `x.y.` número da versão) não tem novos recursos; versões menores (o `y` aumenta) sim.
 
+- NumPy 1.25.2 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.25.2)) -- _31 de julho de 2023_.
 - NumPy 1.25.1 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.25.1)) -- _8 de julho de 2023_.
-- NumPy 1.24.4 ([notas de lançamento](https://github.com/numpy/numpy/releases/tag/v1.24.4)) -- _26 de junho de 2023_.
+- NumPy 1.24.4 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.24.4)) -- _26 de junho de 2023_.
 - NumPy 1.25.0 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.25.0)) -- _17 de junho de 2023_.
 - NumPy 1.24.3 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.24.3)) -- _22 de abril de 2023_.
 - NumPy 1.24.2 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.24.2)) -- _5 de fevereiro de 2023_.


### PR DESCRIPTION
This PR adds Japanese and Portuguese translations to `news.md` for NumPy version 1.25.2. Manual updates to add translations for release lines will become unnecessary once gh-654 gets in.