### PR TITLE
Publish Japanese and Portuguese translations to main website.

### DIFF
--- a/config.yaml.in
+++ b/config.yaml.in
@@ -8,10 +8,10 @@ markup:
     renderer:
       unsafe: true
 
-# Uncomment this to disable the translations for the specified languages.
-# This may be useful to be able to merge partial translations without deploying
-# them to numpy.org immediately.
-# disableLanguages: []
+# Add two character language codes to disable translations for the specified
+# languages. This may be useful to be able to merge partial translations
+# without deploying them to numpy.org immediately.
+disableLanguages: []
 
 params:
   images:

--- a/config.yaml.in
+++ b/config.yaml.in
@@ -11,7 +11,7 @@ markup:
 # Uncomment this to disable the translations for the specified languages.
 # This may be useful to be able to merge partial translations without deploying
 # them to numpy.org immediately.
-disableLanguages: ["pt", "ja"]
+# disableLanguages: []
 
 params:
   images:

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -11,19 +11,19 @@ _Aug 1, 2023_ -- numpy.org is now available in 2 additional languages:
 Japanese and Portuguese. This wouldn’t be possible without our dedicated volunteers:
 
 _Portuguese:_
-Melissa Weber Mendonça (melissawm)
-Ricardo Prins (ricardoprins)
-Getúlio Silva (getuliosilva)
-Julio Batista Silva (jbsilva)
-Alexandre de Siqueira (alexdesiqueira)
-Alexandre B A Villares (villares)
-Vini Salazar (vinisalazar)
+* Melissa Weber Mendonça (melissawm)
+* Ricardo Prins (ricardoprins)
+* Getúlio Silva (getuliosilva)
+* Julio Batista Silva (jbsilva)
+* Alexandre de Siqueira (alexdesiqueira)
+* Alexandre B A Villares (villares)
+* Vini Salazar (vinisalazar)
 
 _Japanese:_
-Atsushi Sakai (AtsushiSakai)
-KKunai
-Tom Kelly (TomKellyGenetics)
-Yuji Kanagawa (kngwyu)
+* Atsushi Sakai (AtsushiSakai)
+* KKunai
+* Tom Kelly (TomKellyGenetics)
+* Yuji Kanagawa (kngwyu)
 
 The work on the translation infrastructure is supported with funding from CZI.
 

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,9 +1,39 @@
 ---
 title: News
 sidebar: false
-newsHeader: "NumPy 1.25.0 released"
-date: 2023-06-17
+newsHeader: "numpy.org is now available in Japanese and Portuguese"
+date: 2023-08-01
 ---
+
+### numpy.org is now available in Japanese and Portuguese
+
+_Aug 1, 2023_ -- numpy.org is now available in 2 additional languages: 
+Japanese and Portuguese. This wouldn’t be possible without our dedicated volunteers:
+
+_Portuguese:_
+Melissa Weber Mendonça (melissawm)
+Ricardo Prins (ricardoprins)
+Getúlio Silva (getuliosilva)
+Julio Batista Silva (jbsilva)
+Alexandre de Siqueira (alexdesiqueira)
+Alexandre B A Villares (villares)
+Vini Salazar (vinisalazar)
+
+_Japanese:_
+Atsushi Sakai (AtsushiSakai)
+KKunai
+Tom Kelly (TomKellyGenetics)
+Yuji Kanagawa (kngwyu)
+
+The work on the translation infrastructure is supported with funding from CZI.
+
+Looking ahead, we’d love to translate the website into more languages.
+If you’d like to help, please connect with the NumPy Translations Team on Slack:
+https://join.slack.com/t/numpy-team/shared_invite/zt-1gokbq56s-bvEpo10Ef7aHbVtVFeZv2w. 
+(Look for the #translations channel.) We are also building a Translations Team who will be 
+working on localizing documentation and educational content across the Scientific Python 
+ecosystem. If this piqued your interest, join us on the Scientific Python 
+Discord: https://discord.gg/khWtqY6RKr. (Look for the #translation channel.)
 
 ### NumPy 1.25.0 released
 

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -24,6 +24,7 @@ _Japanese:_
 * KKunai
 * Tom Kelly (TomKellyGenetics)
 * Yuji Kanagawa (kngwyu)
+* Tetsuo Koyama (tkoyama010)
 
 The work on the translation infrastructure is supported with funding from CZI.
 

--- a/content/ja/news.md
+++ b/content/ja/news.md
@@ -11,19 +11,19 @@ _2023年4月1日_ -- numpy.orgが2つの言語で利用可能になりました�
 日本語とポルトガル語。 私たちの熱心なボランティアがいなければ、これは不可能です：
 
 _ポルトガル語:_
-Melissa Weber Mendonça (melissawm)
-Ricardo Prins (ricardoprins)
-Getúlio Silva (getuliosilva)
-Julio Batista Silva (jbsilva)
-Alexandre de Siqueira (alexdesiqueira)
-Alexandre B A Villares (villares)
-Vini Salazar (vinisalazar)
+* Melissa Weber Mendonça (melissawm)
+* Ricardo Prins (ricardoprins)
+* Getúlio Silva (getuliosilva)
+* Julio Batista Silva (jbsilva)
+* Alexandre de Siqueira (alexdesiqueira)
+* Alexandre B A Villares (villares)
+* Vini Salazar (vinisalazar)
 
 _日本語:_
-Atsushi Sakai (AtsushiSakai)
-KKunai
-Tom Kelly (TomKellyGenetics)
-Yuji Kanagawa (kngwyu)
+* Atsushi Sakai (AtsushiSakai)
+* KKunai
+* Tom Kelly (TomKellyGenetics)
+* Yuji Kanagawa (kngwyu)
 
 翻訳インフラストラクチャに関する作業は、CZIからの資金援助でサポートされています。
 

--- a/content/ja/news.md
+++ b/content/ja/news.md
@@ -24,6 +24,7 @@ _日本語:_
 * KKunai
 * Tom Kelly (TomKellyGenetics)
 * Yuji Kanagawa (kngwyu)
+* Tetsuo Koyama (tkoyama010)
 
 翻訳インフラストラクチャに関する作業は、CZIからの資金援助でサポートされています。
 

--- a/content/ja/news.md
+++ b/content/ja/news.md
@@ -1,9 +1,33 @@
 ---
 title: ニュース
 sidebar: false
-newsHeader: "NumPy 1.25.0 リリース"
-date: 2023-06-17
+newsHeader: "numpy.orgが日本語とポルトガル語に対応しました。"
+date: 2023-08-01
 ---
+
+### numpy.orgが日本語とポルトガル語に対応しました。
+
+_2023年4月1日_ -- numpy.orgが2つの言語で利用可能になりました：
+日本語とポルトガル語。 私たちの熱心なボランティアがいなければ、これは不可能です：
+
+_ポルトガル語:_
+Melissa Weber Mendonça (melissawm)
+Ricardo Prins (ricardoprins)
+Getúlio Silva (getuliosilva)
+Julio Batista Silva (jbsilva)
+Alexandre de Siqueira (alexdesiqueira)
+Alexandre B A Villares (villares)
+Vini Salazar (vinisalazar)
+
+_日本語:_
+Atsushi Sakai (AtsushiSakai)
+KKunai
+Tom Kelly (TomKellyGenetics)
+Yuji Kanagawa (kngwyu)
+
+翻訳インフラストラクチャに関する作業は、CZIからの資金援助でサポートされています。
+
+今後は、ウェブサイトをより多くの言語に翻訳したいと思います。 手伝いたい場合は、Slack上のNumPy翻訳チームと繋がってください: https://join.slack.com/t/numpy-team/shared_invite/zt-1gokbq56s-bvEpo10Ef7aHbVtVFeZv2w. (#translations チャンネルを探してください) また、Scientific Pythonエコシステム全体のドキュメントや教育コンテンツのローカライズに取り組む 翻訳チームも 立ち上げています。 これが興味を引いた場合は、Scientific Python Discordに参加してください: https://discord.gg/khWtqY6RKr (#translation チャンネルを探してください)
 
 ### NumPy 1.25.0 リリース
 

--- a/content/pt/config.yaml
+++ b/content/pt/config.yaml
@@ -93,7 +93,7 @@ params:
       url: /pt/news
     - 
       title: Contribuir
-      url: /contribute
+      url: /pt/contribute
   footer:
     logo: logo.svg
     socialmediatitle: ""

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -5,6 +5,31 @@ newsHeader: "Lançado o NumPy 1.25.0"
 date: 2023-06-17
 ---
 
+### numpy.org agora está disponível em Japonês e Português
+
+Estamos felizes em anunciar que o site numpy.org agora está disponível em duas línguas adicionais além do Inglês: Japonês e Português Brasileiro. Isso não teria sido possível sem nosso grupo de voluntários: 
+
+Portuguese:
+* Melissa Weber Mendonça (melissawm)
+* nRicardo Prins (ricardoprins)
+* Getúlio Silva (getuliosilva)
+* Julio Batista Silva (jbsilva)
+* Alexandre de Siqueira (alexdesiqueira)
+* Alexandre B A Villares (villares)
+* Vini Salazar (vinisalazar)
+
+Japanese:
+* Atsushi Sakai (AtsushiSakai)
+* KKunai
+* Tom Kelly (TomKellyGenetics)
+* Yuji Kanagawa (kngwyu)
+
+O trabalho na infraestrutura de traduções é financiado pela CZI.
+
+No futuro, adoraríamos traduzir o site para mais línguas. Se você quiser ajudar, por favor entre em contato com o time de traduções do NumPy no Slack:
+https://join.slack.com/t/numpy-team/shared_invite/zt-1gokbq56s-bvEpo10Ef7aHbVtVFeZv2w. (Procure pelo canal #translations)
+Também estamos organizando um time de tradutores que serão responsáveis por trabalhar na localização da documentação e conteúdo educacional para o ecossistema Scientific Python. Se esse trabalho te interessa, junte-se a nós no Discord do projeto Scientific Python: https://discord.gg/khWtqY6RKr. (Procure pelo canal #translation)
+
 ### Lançado o NumPy 1.25.0
 
 _17 de junho, 2023_ -- [NumPy 1.25.0](https://numpy.org/doc/stable/release/1.25.0-notes.html) está disponível agora. Os destaques desta versão são:

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -9,7 +9,7 @@ date: 2023-06-17
 
 Estamos felizes em anunciar que o site numpy.org agora está disponível em duas línguas adicionais além do Inglês: Japonês e Português Brasileiro. Isso não teria sido possível sem nosso grupo de voluntários: 
 
-Portuguese:
+Português:
 * Melissa Weber Mendonça (melissawm)
 * Ricardo Prins (ricardoprins)
 * Getúlio Silva (getuliosilva)
@@ -18,7 +18,7 @@ Portuguese:
 * Alexandre B A Villares (villares)
 * Vini Salazar (vinisalazar)
 
-Japanese:
+Japonês:
 * Atsushi Sakai (AtsushiSakai)
 * KKunai
 * Tom Kelly (TomKellyGenetics)

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -11,7 +11,7 @@ Estamos felizes em anunciar que o site numpy.org agora está disponível em duas
 
 Portuguese:
 * Melissa Weber Mendonça (melissawm)
-* nRicardo Prins (ricardoprins)
+* Ricardo Prins (ricardoprins)
 * Getúlio Silva (getuliosilva)
 * Julio Batista Silva (jbsilva)
 * Alexandre de Siqueira (alexdesiqueira)

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -23,6 +23,7 @@ Japanese:
 * KKunai
 * Tom Kelly (TomKellyGenetics)
 * Yuji Kanagawa (kngwyu)
+* Tetsuo Koyama (tkoyama010)
 
 O trabalho na infraestrutura de traduções é financiado pela CZI.
 

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -1,7 +1,7 @@
 ---
 title: Notícias
 sidebar: false
-newsHeader: "Lançado o NumPy 1.25.0"
+newsHeader: "numpy.org agora está disponível em Japonês e Português"
 date: 2023-06-17
 ---
 


### PR DESCRIPTION
Japanese and Portuguese translations have been completed and validated. This PR comments out the `disableLanguages` line in `config.yaml.in`. Once merged, this PR will make the Japanese and Portuguese translations available on numpy.org. On the desktop version of the page, a small drop-down for selecting the language will become available in the header:

![image](https://github.com/numpy/numpy.org/assets/1953382/35ef53df-e18e-4ebb-9cfc-8946eaf02d92)

On mobile, options to select the language will be added to the hamburger menu:

<img src="https://github.com/numpy/numpy.org/assets/1953382/8ebe5ebb-2d91-4777-abce-d7e52f7134b4" width=30% height=30%>

Japanese and Portuguese translations will be available at the URLs numpy.org/ja and numpy.org/pt respectively.

For ease of synchronization, I think the updates to `news.md`  to announce the new translations should be made in this PR in English, Japanese, and Portuguese simultaneously.


cc @rgommers, @melissawm, @InessaPawson, @AtsushiSakai 



