### PR TITLE
Install glibc for go 1.20+

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-python@v4
       - name: Generate config.yaml
         run: python gen_config.py
+      - name: Install glibc
+        run: |
+          sudo apt update
+          sudo apt install glibc-source -y
       - name: Publish Site
         uses: chabad360/hugo-gh-pages@master
         with:


### PR DESCRIPTION
Fix to (hopefully) fix gh page build, which currently generates this error:
```
Versions:
Error loading shared library libresolv.so.2: No such file or directory (needed by /usr/bin/hugo)
Error relocating /usr/bin/hugo: __res_search: symbol not found
Hugo: 
```

The `libresolv.so.2` dependency was introduced in go 1.20.

I don't use Ubuntu, but on my Fedora box I have:
```
$ rpm -qf /usr/lib64/libresolv.so
glibc-devel-2.37-4.fc38.x86_64
```

I didn't see glibc listed here:
https://github.com/actions/runner-images/blob/ubuntu22/20230728.3/images/linux/Ubuntu2204-Readme.md

I followed the instructions here:
https://itslinuxfoss.com/install-glibc-ubuntu/