### PR TITLE
Update GH pages workflow to not depend on external action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,28 +1,69 @@
-# https://github.com/chabad360/hugo-gh-pages
+# https://gohugo.io/hosting-and-deployment/hosting-on-github/
+
 name: github pages
+
+env:
+  HUGO_VERSION: 0.116.1
 
 on:
   push:
     branches:
       - main
+      - deploy
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
+      - name: Install Hugo CLI
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
+      - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Setup Python
-        uses: actions/setup-python@v4
-      - name: Generate config.yaml
+          fetch-depth: 0
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Generate config
         run: python gen_config.py
-      - name: Publish Site
-        uses: chabad360/hugo-gh-pages@master
+      - name: Build with Hugo
+        run: |
+          hugo \
+            --gc \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          githubToken: ${{ secrets.PERSONAL_TOKEN }}
-          branch: main
-          cname: numpy.org
-          repo: numpy/numpy.github.com
-          hugoVersion: extended_0.116.1
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
Use GitHub's new deploy action mechanism, getting rid of the action that relies on an Alpine Docker image, causing trouble with Hugo.