### PR TITLE
Update date in news.md header to today's date

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -2,7 +2,7 @@
 title: News
 sidebar: false
 newsHeader: "numpy.org is now available in Japanese and Portuguese"
-date: 2023-08-01
+date: 2023-08-02
 ---
 
 ### numpy.org is now available in Japanese and Portuguese

--- a/content/ja/news.md
+++ b/content/ja/news.md
@@ -2,7 +2,7 @@
 title: ニュース
 sidebar: false
 newsHeader: "numpy.orgが日本語とポルトガル語に対応しました。"
-date: 2023-08-01
+date: 2023-08-02
 ---
 
 ### numpy.orgが日本語とポルトガル語に対応しました。

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -2,7 +2,7 @@
 title: Notícias
 sidebar: false
 newsHeader: "numpy.org agora está disponível em Japonês e Português"
-date: 2023-06-17
+date: 2023-08-02
 ---
 
 ### numpy.org agora está disponível em Japonês e Português


### PR DESCRIPTION
This PR updates the date in the header for news.md to today's date for English, Japanese, and Portuguese.