### PR TITLE
Fix broken newsLinks for Portuguese and Japanese

### DIFF
--- a/content/ja/news.md
+++ b/content/ja/news.md
@@ -3,6 +3,7 @@ title: ニュース
 sidebar: false
 newsHeader: "numpy.orgが日本語とポルトガル語に対応しました。"
 date: 2023-08-02
+newsLink: /ja/news
 ---
 
 ### numpy.orgが日本語とポルトガル語に対応しました。

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -3,6 +3,7 @@ title: Notícias
 sidebar: false
 newsHeader: "numpy.org agora está disponível em Japonês e Português"
 date: 2023-08-02
+newsLink: /pt/news
 ---
 
 ### numpy.org agora está disponível em Japonês e Português


### PR DESCRIPTION
This PR fixes newsLink for news.md to point to the correct languages. Currently the link below:

![image](https://github.com/numpy/numpy.org/assets/1953382/ef99b917-44a1-429f-b964-3f50ad5311b0)

points to the English language news page regardless of language selected.