### PR TITLE
DOC: remove Processes from astronomy

### DIFF
--- a/content/en/tabcontents.yaml
+++ b/content/en/tabcontents.yaml
@@ -100,7 +100,7 @@ params:
     - title: Graphs and Networks
       alttext: A simple graph.
       img: /images/content_images/sc_dom_img/sd6.svg
-    - title: Astronomy Processes
+    - title: Astronomy
       alttext: A telescope.
       img: /images/content_images/sc_dom_img/astronomy_processes.svg
     - title: Cognitive Psychology


### PR DESCRIPTION
"Astronomy Processes" sounds extremely weird, I would suggest to drop the "Processes" part.



