### PR TITLE
Fix overlap in text for Japanese translation

### DIFF
--- a/assets/css/tabs.css
+++ b/assets/css/tabs.css
@@ -109,6 +109,7 @@ tr.highlight-th {
 td.bold-text {
     font-weight: bold;
     text-align: center;
+    min-width: 120px;
 }
 
 .scientific-domains td.bold-text {


### PR DESCRIPTION
#### Brief description of what is fixed or changed

The Scientific Domain tab in the home page has overlapping text for the Japanese version (and also for the English version on mobile). These changes prevents overlap but are not responsive on mobile.

Before, on desktop:
<img width="1080" alt="Screenshot 2023-08-02 at 15 26 56" src="https://github.com/numpy/numpy.org/assets/3949932/7f83e66c-830f-42f5-96bb-ecb81573d9b8">

After:
<img width="1080" alt="Screenshot 2023-08-02 at 15 27 41" src="https://github.com/numpy/numpy.org/assets/3949932/f797610e-af18-4302-bc6c-6f62072534f7">


