### PR TITLE
MAINT: Remove promoting twitter in heading

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -93,8 +93,6 @@ params:
       icon: github
     - link: https://www.youtube.com/channel/UCguIL9NZ7ybWK5WQ53qbHng
       icon: youtube
-    - link: https://twitter.com/numpy_team
-      icon: twitter
     quicklinks:
       column1:
         title: ""

--- a/content/ja/config.yaml
+++ b/content/ja/config.yaml
@@ -104,9 +104,6 @@ params:
       - 
         link: https://www.youtube.com/channel/UCguIL9NZ7ybWK5WQ53qbHng
         icon: YouTube
-      - 
-        link: https://twitter.com/numpy_team
-        icon: twitter
     quicklinks:
       column1:
         title: ""

--- a/content/pt/config.yaml
+++ b/content/pt/config.yaml
@@ -104,9 +104,6 @@ params:
       - 
         link: https://www.youtube.com/channel/UCguIL9NZ7ybWK5WQ53qbHng
         icon: youtube
-      - 
-        link: https://twitter.com/numpy_team
-        icon: twitter
     quicklinks:
       column1:
         title: ""


### PR DESCRIPTION
I noticed the prominent placing of the logo on the docs pages, IMO while it's OK to have github there it probably shouldn't pick and choose one social media to go with it, too.
