### PR TITLE
Set crowdin update_option to update_as_unapproved

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -5,10 +5,13 @@ preserve_hierarchy: true
 files:
   - source: /content/en/*.yaml
     translation: /content/%two_letters_code%/%original_file_name%
+    update_option: "update_as_unapproved"
   - source: /content/en/*.md
     translation: /content/%two_letters_code%/%original_file_name%
+    update_option: "update_as_unapproved"
     ignore:
       - /content/en/terms.md
       - /content/en/diversity_sep2020.md
   - source: /content/en/case-studies/*.md
     translation: /content/%two_letters_code%/case-studies/%original_file_name%
+    update_option: "update_as_unapproved"


### PR DESCRIPTION
This PR changes `update_option` in `crowdin.yml` to `update_as_unapproved` in all cases. This makes it so when a source string changes, the translation is not lost, it only becomes unapproved. We have had an issue where changes in the structure of a page, or additions of news items, to cause Crowdin to think source strings have changed when that is not really the case. In the past I have gone through and manually added translations back, but then the information about who first added the translation is lost. With the new option, someone can go check if the strings have actually changed or not, and approve them if they have not without having to involve the translators, and while preserving who originally made the contributions.

See the  [Crowdin documentation](https://developer.crowdin.com/configuration-file/#changed-strings-update) for more information.

