### PR TITLE
update latest release button in all languages

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -10,7 +10,7 @@ params:
     # Hero subtitle (optional)
     subtitle: The fundamental package for scientific computing with Python
     # Button text
-    buttontext: "Latest release: NumPy 1.25. View all releases"
+    buttontext: "Latest release: NumPy 1.26. View all releases"
     # Where the main hero button links to
     buttonlink: "/news/#releases"
     # Hero image (from static/images/___)

--- a/content/ja/config.yaml
+++ b/content/ja/config.yaml
@@ -10,7 +10,7 @@ params:
     #Hero subtitle (optional)
     subtitle: Pythonによる科学技術計算の基礎パッケージ
     #Button text
-    buttontext: "最新リリース: Numpy 1.25. すべてのリリースを表示する"
+    buttontext: "最新リリース: Numpy 1.26. すべてのリリースを表示する"
     #Where the main hero button links to
     buttonlink: "/ja/news/#releases"
     #Hero image (from static/images/___)

--- a/content/pt/config.yaml
+++ b/content/pt/config.yaml
@@ -10,7 +10,7 @@ params:
     #Hero subtitle (optional)
     subtitle: A biblioteca fundamental para computação científica com Python
     #Button text
-    buttontext: "Última versão: NumPy 1.25. Veja todas as versões"
+    buttontext: "Última versão: NumPy 1.26. Veja todas as versões"
     #Where the main hero button links to
     buttonlink: "/pt/news/#releases"
     #Hero image (from static/images/___)


### PR DESCRIPTION
Fixes numpy/numpy#24744. Note the news fragment is out of sync: the English one highlights the 1.26 release where the Japanese and Portuguese still have an older news fragment.