### PR TITLE
Meta: (Makefile) Add serve-dev rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,11 @@ teams: | teams-clean $(patsubst %,$(TEAMS_DIR)/%.md,$(TEAMS)) ## generates numpy
 serve: prepare ## serve the website
 	hugo $(BASEURLARG) --printI18nWarnings server -D
 
+# Serve the site for development purposes (leaving submodules as-is, etc).
+serve-dev:
+	python gen_config.py
+	hugo $(BASEURLARG) --printI18nWarnings server --buildDrafts --disableFastRender --poll 1000ms
+
 html: prepare ## build the website in ./public
 	hugo $(BASEURLARG)
 


### PR DESCRIPTION
This rule does not touch submodules, which allows the site to be served with a different commit in a submodule.  It also sets a couple of Hugo options which make the server's automatic rebuilding and refreshing more reliable.  (See <https://github.com/gohugoio/hugo/issues/10893>.)

https://github.com/numpy/numpy.org/pull/526 is also relevant, but unless and until that PR is advanced, the simple change in this PR provides a necessary enhancement for working with the numpy.org source code as the theme is being developed.

Thanks.