### PR TITLE
L10n pt updates 2023 11 17

### DIFF
--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -45,8 +45,8 @@ A liderança do projeto NumPy trabalha ativamente na diversificação dos caminh
 - website
 - pesquisa
 - traduções
-- otimização
 - mentores para sprints de desenvolvimento
+- otimização
 - financiamento e bolsas
 
 Veja a página sobre os [Times]({{< relref "/teams" >}}) para mais informações.

--- a/content/pt/config.yaml
+++ b/content/pt/config.yaml
@@ -158,4 +158,3 @@ params:
           - 
             text: Kit de imprensa
             link: /pt/press-kit
-

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -26,7 +26,6 @@ _2 de agosto de 2023_ -- numpy.org agora está disponível em 2 idiomas adiciona
 
 _Português:_
 * Melissa Weber Mendonça (melissawm)
->>>>>>> 2ea4033 (New translations news.md (Portuguese, Brazilian))
 * Ricardo Prins (ricardoprins)
 * Getúlio Silva (getuliosilva)
 * Julio Batista Silva (jbsilva)

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -1,17 +1,32 @@
 ---
 title: Notícias
 sidebar: false
-newsHeader: "numpy.org agora está disponível em Japonês e Português"
-date: 2023-08-02
-newsLink: /pt/news
+newsHeader: "NumPy versão 1.26.0"
+date: 2023-09-16
 ---
 
-### numpy.org agora está disponível em Japonês e Português
+### Lançado o NumPy versão 1.26.0
 
-_02 de agosto, 2023_ -- Estamos felizes em anunciar que o site numpy.org agora está disponível em duas línguas adicionais além do Inglês: Japonês e Português Brasileiro. Isso não teria sido possível sem nosso grupo de voluntários: 
+_16 de setembro de 2023_ -- [NumPy 1.26.0](https://numpy.org/doc/stable/release/1.26.0-notes.html) está disponível. Os destaques desta versão são:
 
-Português:
-* Melissa Weber Mendonça (melissawm)
+* Suport ao Python 3.12.0.
+* Compatibilidade com Cython 3.0.0.
+* Utilização do sistema Meson para compilação
+* Suport a SIMD atualizado
+* Melhorias para f2py, suporte a meson e bind(x)
+* Suporte à versão mais recente da biblioteca Accelerate BLAS/LAPACK
+
+A versão 1.26.0 é uma continuação da série de versões 1.25.x que marcam a transição para o sistema de compilação Meson e oferecem suporte preliminar para o Cython 3.0.0. Um total de 20 pessoas contribuíram para este lançamento e 59 pull requests foram incorporadas.
+
+As versões do Python suportadas por esta versão são 3.9-3.12.
+
+### numpy.org agora está disponível em japonês e português
+
+_2 de agosto de 2023_ -- numpy.org agora está disponível em 2 idiomas adicionais: japonês e português. Isto não seria possível sem nossos voluntários dedicados:
+
+_Português:_
+* Melissa Weber Mendonça (melissawm)
+>>>>>>> 2ea4033 (New translations news.md (Portuguese, Brazilian))
 * Ricardo Prins (ricardoprins)
 * Getúlio Silva (getuliosilva)
 * Julio Batista Silva (jbsilva)
@@ -31,8 +46,6 @@ O trabalho na infraestrutura de traduções é financiado pela CZI.
 No futuro, adoraríamos traduzir o site para mais línguas. Se você quiser ajudar, por favor entre em contato com o time de traduções do NumPy no Slack:
 https://join.slack.com/t/numpy-team/shared_invite/zt-1gokbq56s-bvEpo10Ef7aHbVtVFeZv2w. (Procure pelo canal #translations)
 Também estamos organizando um time de tradutores que serão responsáveis por trabalhar na localização da documentação e conteúdo educacional para o ecossistema Scientific Python. Se esse trabalho te interessa, junte-se a nós no Discord do projeto Scientific Python: https://discord.gg/khWtqY6RKr. (Procure pelo canal #translation)
-
-### Lançado o NumPy 1.25.0
 
 _17 de junho, 2023_ -- [NumPy 1.25.0](https://numpy.org/doc/stable/release/1.25.0-notes.html) está disponível agora. Os destaques desta versão são:
 
@@ -213,6 +226,9 @@ Mais detalhes sobre nossas propostas e resultados esperados podem ser encontrado
 
 Aqui está uma lista de versões do NumPy, com links para notas de lançamento. Bugfix lança (apenas o `z` muda no `x.y.` número da versão) não tem novos recursos; versões menores (o `y` aumenta) sim.
 
+- NumPy 1.26.2 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.26.2)) -- _12 de novembro de 2023_.
+- NumPy 1.26.1 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.26.1)) -- _14 de outubro de 2023_.
+- NumPy 1.26.0 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.26.0)) -- _16 de setembro de 2023_.
 - NumPy 1.25.2 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.25.2)) -- _31 de julho de 2023_.
 - NumPy 1.25.1 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.25.1)) -- _8 de julho de 2023_.
 - NumPy 1.24.4 ([notas de versão](https://github.com/numpy/numpy/releases/tag/v1.24.4)) -- _26 de junho de 2023_.

--- a/content/pt/news.md
+++ b/content/pt/news.md
@@ -9,7 +9,7 @@ date: 2023-09-16
 
 _16 de setembro de 2023_ -- [NumPy 1.26.0](https://numpy.org/doc/stable/release/1.26.0-notes.html) está disponível. Os destaques desta versão são:
 
-* Suport ao Python 3.12.0.
+* Suporte ao Python 3.12.0.
 * Compatibilidade com Cython 3.0.0.
 * Utilização do sistema Meson para compilação
 * Suport a SIMD atualizado

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -83,7 +83,6 @@ params:
       - 
         title: uarray
         text: Sistema de backend Python que dissocia a API da implementação; unumpy fornece uma API NumPy.
->>>>>>> 74181d4 (New translations tabcontents.yaml (Portuguese, Brazilian))
         img: /images/content_images/arlib/uarray.png
         alttext: uarray
         url: https://uarray.org/en/latest/

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -76,7 +76,7 @@ params:
         url: https://github.com/xtensor-stack/xtensor-python
       - 
         title: Awkward Array
-        text: Manipulate JSON-like data with NumPy-like idioms.
+        text: Manipulação de dados JSON-like com sintaxe NumPy-like.
         img: /images/content_images/arlib/awkward.svg
         alttext: awkward
         url: https://awkward-array.org/

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -75,14 +75,15 @@ params:
         alttext: xtensor
         url: https://github.com/xtensor-stack/xtensor-python
       - 
-        title: XND
-        text: Desenvolva bibliotecas para computação com arrays, recriando conceitos fundamentais do NumPy.
-        img: /images/content_images/arlib/xnd.png
-        alttext: xnd
-        url: https://xnd.io
+        title: Awkward Array
+        text: Manipulate JSON-like data with NumPy-like idioms.
+        img: /images/content_images/arlib/awkward.svg
+        alttext: awkward
+        url: https://awkward-array.org/
       - 
         title: uarray
         text: Sistema de backend Python que dissocia a API da implementação; unumpy fornece uma API NumPy.
+>>>>>>> 74181d4 (New translations tabcontents.yaml (Portuguese, Brazilian))
         img: /images/content_images/arlib/uarray.png
         alttext: uarray
         url: https://uarray.org/en/latest/


### PR DESCRIPTION

#### Brief description of what is fixed or changed
This PR adds recent updates made to the Portuguese translations. Similar to gh-698, to handle lack of synchrony between Crowdin and the actually published translations, I did a scripted rebase which filtered to just portuguese commits, and squashed all commits together which had touched the same file. I then rebased on main and manually fixed the merge conflicts. @melissawm, please let me know if everything looks OK.

Also, it appears XND has been replaced by Awkward Array in the list of dependent projects in the table of contents. The description "Manipulate JSON-like data with NumPy-like idioms." is currently untranslated.

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

