### PR TITLE
Enable and fix for dark mode

### DIFF
--- a/assets/css/tabs.scss
+++ b/assets/css/tabs.scss
@@ -13,6 +13,10 @@ table td, table th {
 .tabs-section {
     display: flex;
     flex-direction: column;
+
+    html[data-theme=dark] & img {
+        filter: invert(1) !important;
+    }
 }
 
 .tabs-section .container {
@@ -133,10 +137,6 @@ img.first-column-layout {
     max-width: 100px;
     max-height: 30px;
     margin: 0px 20px 0px 10px;
-
-    html[data-theme=dark] & {
-        filter: invert(1) !important;
-    }
 }
 
 td.left-text {

--- a/assets/css/tabs.scss
+++ b/assets/css/tabs.scss
@@ -20,6 +20,14 @@ table td, table th {
 
     & .tabs div li {
         display: inline;
+
+        & .grid-container {
+            margin-top: 1em;
+
+            & p {
+                margin-top: 0em;
+            }
+        }
     }
 }
 

--- a/assets/css/tabs.scss
+++ b/assets/css/tabs.scss
@@ -133,6 +133,10 @@ img.first-column-layout {
     max-width: 100px;
     max-height: 30px;
     margin: 0px 20px 0px 10px;
+
+    html[data-theme=dark] & {
+        filter: invert(1) !important;
+    }
 }
 
 td.left-text {

--- a/assets/css/tabs.scss
+++ b/assets/css/tabs.scss
@@ -109,6 +109,10 @@ section.scientific-domains {
                 width: 50px;
                 height: 50px;
                 margin-bottom: 0.5em;
+
+                html[data-theme=dark] & {
+                    filter: invert(1) grayscale(1) !important;
+                }
             }
             & ul {
                 align-content: left;

--- a/assets/css/tabs.scss
+++ b/assets/css/tabs.scss
@@ -17,6 +17,10 @@ table td, table th {
     html[data-theme=dark] & img {
         filter: invert(1) !important;
     }
+
+    & .tabs div li {
+        display: inline;
+    }
 }
 
 .tabs-section .container {

--- a/config.yaml.in
+++ b/config.yaml.in
@@ -14,7 +14,6 @@ markup:
 disableLanguages: []
 
 params:
-  colorScheme: light
   author:
     name: "NumPy team"
   images:


### PR DESCRIPTION
See https://github.com/numpy/numpy.org/issues/707.

- [x] Undo https://github.com/numpy/numpy.org/commit/a85637404e6c80d808cd93271b8dbbe346f41761: https://github.com/numpy/numpy.org/pull/708/commits/5dfb7969544515d7f8dd469865d9b53c12077ea5
- [x]  Logos not rendering well in dark mode (scientific domains; sponsorships on About):
  - https://github.com/numpy/numpy.org/pull/708/commits/bbf3708864445ad22a90b67a085c22ae42650aeb
  - https://github.com/numpy/numpy.org/pull/708/commits/b8a2621401c7982e58ffadc9bfb5cfdd6fe4ac25
  - https://github.com/numpy/numpy.org/pull/708/commits/ab211a573e0976de3739323666262007eb73778a
- [x] Tabs:
  * [x] "Array libraries" tab: logo images need filtering: 6c78d3bef7036bea0b1152d7dfafabec44935343
  * [X] "Data Science", "Machine Learning", "Visualization" tabs: colors need fixing: https://github.com/numpy/numpy.org/pull/708/commits/6c78d3bef7036bea0b1152d7dfafabec44935343
  * [x] "Visualization" tab's images: https://github.com/numpy/numpy.org/pull/708/commits/5b8a04b4d835045cfbaf86bb449e59d3f45eb54d
  * [x] Some tabs have a ~li~ bullet at the top of their contents: https://github.com/numpy/numpy.org/pull/708/commits/c0d23b7e08ab80b0588973793668b6ea6d7ecfa3
  * [x] Content top-margin larger for text than images: https://github.com/numpy/numpy.org/pull/708/commits/1d40832e5f7cdab405e67f6b2d63a461479169e6
- [x]  Language drop down: wrong color in dark mode (should be fixed in theme?)
  - [x] Fixed in https://github.com/scientific-python/scientific-python-hugo-theme/pull/435