### PR TITLE
NumFOCUS Subcommittee update

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -56,7 +56,7 @@ See the [Team]({{< relref "/teams" >}}) page for more info.
 
 - Charles Harris
 - Ralf Gommers
-- Melissa Weber Mendonça
+- Inessa Pawson
 - Sebastian Berg
 - External member: Thomas Caswell
 

--- a/content/ja/about.md
+++ b/content/ja/about.md
@@ -55,7 +55,7 @@ Numpy プロジェクトのコアメンバーは、プロジェクトへの貢�
 
 - Charles Harris
 - Ralf Gommers
-- Melissa Weber Mendonça
+- Inessa Pawson
 - Sebastian Berg
 - 外部メンバー: Thomas Caswell
 

--- a/content/pt/about.md
+++ b/content/pt/about.md
@@ -55,7 +55,7 @@ Veja a página sobre os [Times]({{< relref "/teams" >}}) para mais informações
 
 - Charles Harris
 - Ralf Gommers
-- Melissa Weber Mendonça
+- Inessa Pawson
 - Sebastian Berg
 - Membro externo: Thomas Caswell
 


### PR DESCRIPTION
On March 22nd, 2023, Melissa nominated me to join the NumFOCUS Subcommittee in her place via the NumPy Steering Council mailing list. I accepted the nomination and have been performing my duties for the past 9 months. This PR reflects the change in the Subcommittee membership.

