### PR TITLE
Update news bar to point to latest feature release again

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,8 +1,8 @@
 ---
 title: News
 sidebar: false
-newsHeader: "NumFOCUS + PyCharm end of the year fundraiser"
-date: 2023-12-19
+newsHeader: "NumPy 1.26.0 released"
+date: 2023-09-16
 ---
 
 ### NumFOCUS end of the year fundraiser
@@ -11,7 +11,7 @@ on first-time PyCharm licenses. All year-one revenue from PyCharm purchases from
 until December 23rd, 2023 will go directly to the NumFOCUS programs. 
 
 Use unique URL that will allow to track purchases https://lp.jetbrains.com/support-data-science/ 
-or a coupon code: ISUPPORTDATASCIENCE 
+or a coupon code ISUPPORTDATASCIENCE 
 
 ### NumPy 1.26.0 released
 


### PR DESCRIPTION
Changing info in the news bar on the home page to the announcement about the 1.26 release since the NF EOY fundraiser ended on Dec 23, 2023.
