### PR TITLE
Update hugo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 # unless otherwise overridden by more specific contexts.
 [build.environment]
   PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
-  HUGO_VERSION = "0.123.7"
+  HUGO_VERSION = "0.123.8"
   DART_SASS_VERSION = "1.71.1"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 


### PR DESCRIPTION
With 0.123.8 (it worked fine with 0.123.2 and 0.123.7), we get this error:
```
Error: error building site: render: failed to render pages: render of "page" failed: "/home/jarrod/src/hugo/numpy.org/themes/scientific-python-hugo-theme/layouts/_default/baseof.html:9:7": execute of template failed: template: _default/single.html:9:7: executing "_default/single.html" at <partial "css.html" .>: error calling partial: "/home/jarrod/src/hugo/numpy.org/themes/scientific-python-hugo-theme/layouts/partials/css.html:43:34": execute of template failed: template: partials/css.html:43:34: executing "partials/css.html" at <resources.ExecuteAsTemplate>: error calling ExecuteAsTemplate: type <nil> not supported in Resource transformations
```
With 0.123.7, this
```
{{- $sass := append (resources.Get "theme-css/sphinx-design/index.scss")
                    (resources.Get "theme-css/pst/pydata-sphinx-theme.scss")
                    (resources.Get "theme-css/spht/index.scss")
                    (resources.Match "theme-css/*.scss")
           | append (resources.Match "css/*.scss") -}}

{{ $sass }}
```
resulted in
```
[/theme-css/sphinx-design/index.scss /theme-css/pst/pydata-sphinx-theme.scss /theme-css/spht/index.scss /css/tabs.scss] 
```
with 0.123.8 it produces
```
[/theme-css/sphinx-design/index.scss /theme-css/pst/pydata-sphinx-theme.scss /theme-css/spht/index.scss tabs.scss] 
```

The difference is with 0.123.7 we got
```
/css/tabs.scss
```
with 0.123.8 we get
```
tabs.scs
```