### PR TITLE
Use new grid syntax

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -2,48 +2,48 @@
 title:
 ---
 
-{{< grid columns="1 2 2 3" >}}
+{{< grid1 columns="1 2 2 3" >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Powerful N-dimensional arrays'
 body = '''
 Fast and versatile, the NumPy vectorization, indexing, and broadcasting concepts are the de-facto standards of array computing today.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Numerical computing tools'
 body = '''
 NumPy offers comprehensive mathematical functions, random number generators, linear algebra routines, Fourier transforms, and more.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Open source'
 body = '''
 Distributed under a liberal [BSD license](https://github.com/numpy/numpy/blob/main/LICENSE.txt), NumPy is developed and maintained [publicly on GitHub](https://github.com/numpy/numpy) by a vibrant, responsive, and diverse [community](/community).
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Interoperable'
 body = '''
 NumPy supports a wide range of hardware and computing platforms, and plays well with distributed, GPU, and sparse array libraries.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Performant'
 body = '''
 The core of NumPy is well-optimized C code. Enjoy the flexibility of Python with the speed of compiled code.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Easy to use'
 body = '''
 NumPy's high level syntax makes it accessible and productive for programmers from any background or experience level.
 '''
-{{< /card >}}
 
-{{< /grid >}}
+{{< /grid1>}}

--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -2,51 +2,51 @@
 title:
 ---
 
-{{< grid columns="1 2 2 3" >}}
+{{< grid1 columns="1 2 2 3" >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = '強力な多次元配列'
 body = '''
 NumPyの高速で多機能なベクトル化計算、インデックス処理、ブロードキャストの考え方は、現在の配列計算におけるデファクト・スタ>ンダードです。
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = '数値計算ツール群'
 body = '''
 NumPyは、様々な数学関数、乱数生成器、線形代数ルーチン、フーリエ変換などを提供しています。
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = '相互運用性'
 body = '''
 NumPyは、幅広いハードウェアとコンピューティング・プラットフォームをサポートしており、分散処理、GPU、疎行列ライブラリにも対
 応しています。
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = '高パフォーマンス'
 body = '''
 NumPyの大部分は最適化されたC言語のコードで構成されています。これによりPythonの柔軟性とコンパイルされたコードの高速性の両方
 を享受できます。
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = '使いやすさ'
 body = '''
 NumPyの高水準なシンタックスは、どんなバックグラウンドや経験を持つのプログラマーでも簡単に利用することができ、生産性を高め>ることができます。
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'オープンソース'
 body = '''
 NumPyは、寛容な[BSDライセンス](https://github.com/numpy/numpy/blob/main/LICENSE.txt)で公開されています。NumPyは活発で、互>いを尊重し、多様性を認め合う[コミュニティ](/ja/community)によって、 [GitHub](https://github.com/numpy/numpy)上でオープンに開発されていま
 す.
 '''
-{{< /card >}}
 
-{{< /grid >}}
+{{< /grid1 >}}

--- a/content/pt/_index.md
+++ b/content/pt/_index.md
@@ -2,48 +2,48 @@
 title:
 ---
 
-{{< grid columns="1 2 2 3" >}}
+{{< grid1 columns="1 2 2 3" >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Arrays n-dimensionais poderosas'
 body = '''
 Rápidos e versáteis, os conceitos de vetorização, indexação e broadcasting do NumPy são, na prática, o padrão em computação com arrays.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Ferramentas de computação numérica'
 body = '''
 O NumPy oferece um conjunto completo de funções matemáticas, geradores de números aleatórios, rotinas de álgebra linear, transformadas de Fourier, e mais.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Interoperabilidade'
 body = '''
 O NumPy suporta um grande número de plataformas de hardware e computação, e pode ser combinado com bibliotecas de computação com arrays esparsas, distribuidas ou em GPUs.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Alto desempenho'
 body = '''
 O núcleo do NumPy é feito de código otimizado em C. Experimente a flexibilidade do Python com a velocidade de código compilado.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Fácil de usar'
 body = '''
 A sintaxe de alto nível do NumPy torna-o acessível e produtivo para programadores de qualquer nível de experiência e formação.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Código aberto'
 body = '''
 Distribuido com uma [licença BSD](https://github.com/numpy/numpy/blob/main/LICENSE.txt) liberal, o NumPy é desenvolvido e mantido [publicamente no GitHub](https://github.com/numpy/numpy) por uma [comunidade](/pt/community) vibrante, responsiva, e diversa.
 '''
-{{< /card >}}
 
-{{< /grid >}}
+{{< /grid1 >}}


### PR DESCRIPTION
@steppi @rgommers Switching to the new grid syntax.

v0.13 
- add new syntax via grid1 to theme
- port website to grid1

v0.14
- cp grid1 to grid in theme
- replace grid1 with grid in websites

v0.15
- rm grid1 from theme
- nothing to do for websites