### PR TITLE
Add HyperSpy

### DIFF
--- a/content/en/tabcontents.yaml
+++ b/content/en/tabcontents.yaml
@@ -29,7 +29,7 @@ params:
       alttext: JAX
       url: https://github.com/google/jax
     - title: Xarray
-      text: Labeled, indexed multi-dimensional arrays for advanced analytics and visualization
+      text: Labeled, indexed multi-dimensional arrays for advanced analytics and visualization.
       img: /images/content_images/arlib/xarray.png
       alttext: xarray
       url: https://xarray.pydata.org/en/stable/index.html
@@ -119,6 +119,8 @@ params:
           label: PyWavelets
         - url: https://python-control.org/
           label: python-control
+        - url: https://hyperspy.org/
+          label: HyperSpy
     - title: Image Processing
       alttext: An photograph of the mountains.
       img: /images/content_images/sc_dom_img/image_processing.svg

--- a/layouts/partials/tabs.html
+++ b/layouts/partials/tabs.html
@@ -10,7 +10,7 @@
               Scientific Domains
 	    </button>
 	    <button id="0-tab-1" type="button" role="tab" aria-selected="false" aria-controls="0-tabpanel-1">
-	      Array libraries
+	      Array Libraries
 	    </button>
 	    <button id="0-tab-2" type="button" role="tab" aria-selected="false" aria-controls="0-tabpanel-2">
 	      Data Science


### PR DESCRIPTION
Add the HyperSpy project to the ecosystem as group of libraries that draw heavily on `numpy` and several of its dependents such as `scipy`, `dask` and `sparse`
1. Under "Array libraries" as it provides tools for multi-dimensional data, that can be separated in signal and navigation dimensions
2. Under "Scientific Domains / Signal Processing" as the various HyperSpy extensions provide data analysis features for signals from a number of scientific domains, in particular from the realm of material sciences and electron microscopy
