### PR TITLE
remove unnecessary single bullet point rendered under Ecosystem tabs

### DIFF
--- a/layouts/partials/array-libraries.html
+++ b/layouts/partials/array-libraries.html
@@ -3,7 +3,7 @@
 {{- $intro := index $arraylibraries "intro" }}
 {{- $headers := index $arraylibraries "headers" }}
 {{- $libraries := index $arraylibraries "libraries" }}
-<li class="array-libraries">
+<section class="array-libraries">
     {{- range $intro }}
     <p>
         {{ .text }}
@@ -25,4 +25,4 @@
         </tr>
         {{- end }}
     </table>
-</li>
+</section>

--- a/layouts/partials/data-science.html
+++ b/layouts/partials/data-science.html
@@ -5,7 +5,7 @@
 {{- $examples := index $datascience "examples" }}
 {{- $image1 := index $datascience "image1" }}
 {{- $image2 := index $datascience "image2" }}
-<li class="data-science">
+<section class="data-science">
     <div class="grid-container">
         <div>
             {{- range $image1 }}
@@ -43,4 +43,4 @@
         {{- end }}
         </div>
     </div>
-</li>
+</section>

--- a/layouts/partials/machine-learning.html
+++ b/layouts/partials/machine-learning.html
@@ -2,7 +2,7 @@
 {{- $machinelearning := .Site.Params.machinelearning }}
 {{- $paras := index $machinelearning "paras" }}
 {{- range $paras }}
-<li class="machine-learning">
+<section class="machine-learning">
     <div class="grid-container">
         <div class="animation-holder">
             <a href="https://ai.googleblog.com/2016/12/open-sourcing-embedding-projector-tool.html">
@@ -27,5 +27,5 @@
             </p>
         </div>
     </div>
-</li>
+</section>
 {{- end }}

--- a/layouts/partials/visualization.html
+++ b/layouts/partials/visualization.html
@@ -2,7 +2,7 @@
 {{- $visualization := .Site.Params.visualization }}
 {{- $content := index $visualization "content" }}
 {{- $images := index $visualization "images" }}
-<li class="visualization">
+<section class="visualization">
     <div class="grid-container">
         <div class="visualization-images">
             <div class="image-grid">
@@ -25,4 +25,4 @@
         <div>
         </div>
     </div>
-</li>
+</section>


### PR DESCRIPTION
this removes unnecessary bullet point from "ECOSYSTEM" sections.
e.g. before the change:
![image](https://github.com/numpy/numpy.org/assets/23830955/bab39932-0f80-4ef5-8f23-4faec10925e1)
and after:
![image](https://github.com/numpy/numpy.org/assets/23830955/3af812a0-edb7-49a0-8e27-c02da6230f65)
