### PR TITLE
Remove the link to the NumPy Twitter/X account

### DIFF
--- a/content/en/config.yaml
+++ b/content/en/config.yaml
@@ -79,8 +79,6 @@ params:
       icon: github
     - link: https://www.youtube.com/channel/UCguIL9NZ7ybWK5WQ53qbHng
       icon: youtube
-    - link: https://twitter.com/numpy_team
-      icon: twitter
     quicklinks:
       column1:
         title: ""


### PR DESCRIPTION
Removing the link to the NumPy Twitter/X account as a follow-up on the discussion in https://github.com/numpy/numpy.org/issues/765 and the [NumPy community call on July 31st, 2024](https://github.com/numpy/archive/blob/main/community_meetings/2024/community-2024-07-31.md).

