### PR TITLE
Manual adjustments to numpy.org Spanish translations

### DIFF
--- a/config.yaml.in
+++ b/config.yaml.in
@@ -51,3 +51,12 @@ languages:
     include-files:
       - content/ja/config.yaml
       - content/ja/tabcontents.yaml
+
+    # Spanish
+  es:
+    title: NumPy
+    weight: 4
+    contentDir: content/es
+    include-files:
+      - content/es/config.yaml
+      - content/es/tabcontents.yaml

--- a/content/es/about.md
+++ b/content/es/about.md
@@ -62,7 +62,7 @@ Visita la página de [Equipos](/teams) para más información.
 ## Patrocinadores
 
 NumPy recibe financiación directa de las siguientes fuentes:
-{{< patrocinadores >}}
+{{< sponsors >}}
 
 
 ## Socios institucionales

--- a/content/es/case-studies/blackhole-image.md
+++ b/content/es/case-studies/blackhole-image.md
@@ -4,7 +4,11 @@ sidebar: false
 ---
 
 {{< figure >}}
-src = '/images/content_images/cs/blackhole. pg' title = 'Agujero Negro M87' alt = 'Imagen de agujero negro' attribution = '(Créditos de la imagen: Colaboración del telescopio del Horizonte de Sucesos)' attributionlink = 'https://www. pl.nasa.gov/images/universe/20190410/blackhole20190410.jpg'
+src = '/images/content_images/cs/blackhole. pg'
+title = 'Agujero Negro M87'
+alt = 'Imagen de agujero negro'
+attribution = '(Créditos de la imagen: Colaboración del telescopio del Horizonte de Sucesos)'
+attributionlink = 'https://www. pl.nasa.gov/images/universe/20190410/blackhole20190410.jpg'
 {{< /figure >}}
 
 {{< blockquote cite="https://www.youtube.com/watch?v=BIvezCVcsYs" by="Katie Bouman, *Profesora Asistente, Ciencias de la Computación & Matemáticas, Caltech*"
@@ -39,7 +43,12 @@ El [ Telescopio Event Horizon (EHT) ](https://eventhorizontelescope.org), es un 
     Cuando el objetivo es ver algo nunca antes visto, ¿cómo pueden los científicos estar seguros de que la imagen es correcta?
 
 {{< figure >}}
-src = '/images/content_images/cs/dataprocessbh.png' title = 'Flujo de Trabajo de Procesamiento de Datos EHT' alt = 'flujo de datos' align = 'center' attribution = '(Diagram Credits: The Astrophysical Journal, Event Horizon Telescope Collaboration)' attributionlink = 'https://iopscience.iop.org/article/10.3847/2041-8213/ab0c57'
+src = '/images/content_images/cs/dataprocessbh.png'
+title = 'Flujo de Trabajo de Procesamiento de Datos EHT'
+alt = 'flujo de datos'
+align = 'center'
+attribution = '(Diagram Credits: The Astrophysical Journal, Event Horizon Telescope Collaboration)'
+attributionlink = 'https://iopscience.iop.org/article/10.3847/2041-8213/ab0c57'
 {{< /figure >}}
 
 ## El Rol de NumPy
@@ -51,13 +60,17 @@ La colaboración del EHT respondió a estos desafíos haciendo que los equipos i
 Su trabajo ilustra el rol que desempeña el ecosistema científico de Python en el avance de la ciencia a través del análisis de datos colaborativos.
 
 {{< figure >}}
-src = '/images/content_images/cs/bh_numpy_role.png' alt = 'rol de numpy' title = 'El rol de NumPy en la imagen del agujero negro'
+src = '/images/content_images/cs/bh_numpy_role.png'
+alt = 'rol de numpy'
+title = 'El rol de NumPy en la imagen del agujero negro'
 {{< /figure >}}
 
 Por ejemplo, el paquete de Python [`eht-imaging`][ehtim] proporciona herramientas para simular y realizar reconstrucción de imágenes en datos VLBI. NumPy está en el núcleo del procesamiento de datos de matrices utilizados en este paquete, como se muestra a continuación en el gráfico parcial de dependencias de software.
 
 {{< figure >}}
-src = '/images/content_images/cs/ehtim_numpy.png' alt = 'mapa de dependencias de ehtim resaltando a numpy' title = 'Gráfico de dependencias de software del paquete ehtim resaltando a NumPy'
+src = '/images/content_images/cs/ehtim_numpy.png'
+alt = 'mapa de dependencias de ehtim resaltando a numpy'
+title = 'Gráfico de dependencias de software del paquete ehtim resaltando a NumPy'
 {{< /figure >}}
 
 Además de NumPy, muchos otros paquetes, como [SciPy](https://www.scipy.org) y [Pandas](https://pandas.io), son parte del flujo de procesamiento de datos para fotografiar el agujero negro. Los formatos estándar de archivos astronómicos y transformaciones de tiempo/coordenadas fueron manejados por [Astropy][astropy], mientras que [Matplotlib][mpl] fue utilizado en la visualización de datos a través del flujo de análisis, incluyendo la generación de la imagen final del agujero negro.
@@ -67,7 +80,9 @@ Además de NumPy, muchos otros paquetes, como [SciPy](https://www.scipy.org) y [
 El eficiente y adaptable arreglo n-dimensional que es la característica central de NumPy, permitió a los investigadores manipular grandes conjuntos de datos numéricos, proporcionando una base para la primera imagen de un agujero negro. Un momento histórico en la ciencia ofrece una impresionante evidencia visual de la teoría de Einstein. Este logro abarca no solo los avances tecnológicos sino también la colaboración internacional de más de 200 científicos y algunos de los mejores radio observatorios del mundo.  Algoritmos innovadores y técnicas de procesamiento de datos, mejorando los modelos astronómicos existentes, ayudaron a desvelar un misterio del universo.
 
 {{< figure >}}
-src = '/images/content_images/cs/numpy_dlc_benefits.png' alt = 'beneficios de numpy' title = 'Capacidades clave de NumPy utilizadas'
+src = '/images/content_images/cs/numpy_dlc_benefits.png'
+alt = 'beneficios de numpy'
+title = 'Capacidades clave de NumPy utilizadas'
 {{< /figure >}}
 
 [resolution]: https://eventhorizontelescope.org/press-release-april-10-2019-astronomers-capture-first-image-black-hole

--- a/content/es/case-studies/blackhole-image.md
+++ b/content/es/case-studies/blackhole-image.md
@@ -8,9 +8,9 @@ src = '/images/content_images/cs/blackhole. pg' title = 'Agujero Negro M87' alt 
 {{< /figure >}}
 
 {{< blockquote cite="https://www.youtube.com/watch?v=BIvezCVcsYs" by="Katie Bouman, *Profesora Asistente, Ciencias de la Computación & Matemáticas, Caltech*"
-> }} Capturar imágenes del Agujero Negro M87 es como intentar ver algo que por definición es imposible de ver. 
-> 
-> {{< /blockquote >}}
+>}}
+Capturar imágenes del Agujero Negro M87 es como intentar ver algo que por definición es imposible de ver. 
+{{< /blockquote >}}
 
 ## Un telescopio del tamaño de la Tierra
 

--- a/content/es/case-studies/cricket-analytics.md
+++ b/content/es/case-studies/cricket-analytics.md
@@ -4,7 +4,11 @@ sidebar: false
 ---
 
 {{< figure >}}
-figure src="/images/content_images/cs/ipl-stadium.png'title" caption="IPLT20, el festival de críquet más grande en India" alt="Copa y estadio de la Premier League de Críquet de India" attr="(Créditos de imagen: IPLT20 (copa y logo) & Akash Yadav (estadio))" attrlink="https://unsplash.com/@aksh1802'
+src = '/images/content_images/cs/ipl-stadium.png'
+title = 'IPLT20, el festival de críquet más grande en India'
+alt = 'Copa y estadio de la Premier League de Críquet de India'
+attribution = '(Créditos de imagen: IPLT20 (copa y logo) & Akash Yadav (estadio))'
+attributionlink = 'https://unsplash.com/@aksh1802'
 {{< /figure >}}
 
 {{< blockquote cite="https://www.scoopwhoop.com/sports/ms-dhoni/" by="M S Dhoni, *Jugador Internacional de críquet, ex-capitán del equipo de India, juega para Chennai Super Kings en IPL*"
@@ -27,7 +31,12 @@ Hoy en día, hay abundantes y casi infinitos tesoros de registros y estadística
 * contribución del jugador a las victorias y derrotas para tomar decisiones estratégicas sobre la composición del equipo
 
 {{< figure >}}
-src = '/images/content_images/cs/cricket-pitch.png' title = 'El campo de críquet, el punto focal en el terreno de juego' alt = 'Un campo de cricket con lanzador y bateadores' align = 'center' attribution = '(Image credit: Debarghya Das)' attributionlink = 'http://debarghyadas.com/files/IPLpaper.pdf'
+src = '/images/content_images/cs/cricket-pitch.png'
+title = 'El campo de críquet, el punto focal en el terreno de juego'
+alt = 'Un campo de cricket con lanzador y bateadores'
+align = 'center'
+attribution = '(Image credit: Debarghya Das)'
+attributionlink = 'http://debarghyadas.com/files/IPLpaper.pdf'
 {{< /figure >}}
 
 ### Objetivos Clave de Análisis de Datos
@@ -37,7 +46,11 @@ src = '/images/content_images/cs/cricket-pitch.png' title = 'El campo de críque
 * Además del análisis histórico, se aprovechan los modelos predictivos para determinar los posibles resultados de los partidos, lo cual requiere una cantidad significativa de procesamiento de datos y conocimientos de ciencia de datos, herramientas de visualización y la capacidad de incluir nuevas observaciones en el análisis.
 
 {{< figure >}}
-src = '/images/content_images/cs/player-pose-estimator.png' alt = 'estimador de postura' title = 'Estimador de postura en críquet' attribution = '(Crédito de imagen: connect.vin)' attributionlink = 'https://connect.vin/2019/05/ai-for-cricket-batsman-pose-analysis/'
+src = '/images/content_images/cs/player-pose-estimator.png'
+alt = 'estimador de postura'
+title = 'Estimador de postura en críquet'
+attribution = '(Crédito de imagen: connect.vin)'
+attributionlink = 'https://connect.vin/2019/05/ai-for-cricket-batsman-pose-analysis/'
 {{< /figure >}}
 
 ### Los Desafíos
@@ -67,5 +80,7 @@ El análisis deportivo es un campo en desarrollo. Muchos investigadores y compa�
 El análisis deportivo ha revolucionado la forma en que se juegan los partidos profesionales, especialmente en cuanto a la toma de decisiones estratégicas, que hasta hace poco se basaba principalmente en la "intuición" o en la adherencia a tradiciones pasadas. NumPy constituye una base sólida para un gran conjunto de paquetes de Python que brindan funciones de nivel superior relacionadas con análisis de datos, el aprendizaje automático y los algoritmos de IA. Estos paquetes están ampliamente desplegados para obtener información en tiempo real que ayudan en la toma de decisiones para resultados revolucionarios, tanto en el campo como para sacar conclusiones y hacer negocios alrededor del juego del críquet. Encontrar los parámetros ocultos, patrones y atributos que conducen al resultado de un partido de críquet ayuda a los interesados a tomar nota de la información del juego que de otra forma estarían ocultos en números y estadísticas.
 
 {{< figure >}}
-src = '/images/content_images/cs/numpy_ca_benefits.png' alt = 'Diagrama que muestra los beneficios de usar NumPy para análisis de críquet' title = 'Capacidades claves de NumPy utilizadas'
+src = '/images/content_images/cs/numpy_ca_benefits.png'
+alt = 'Diagrama que muestra los beneficios de usar NumPy para análisis de críquet'
+title = 'Capacidades claves de NumPy utilizadas'
 {{< /figure >}}

--- a/content/es/case-studies/cricket-analytics.md
+++ b/content/es/case-studies/cricket-analytics.md
@@ -8,9 +8,8 @@ figure src="/images/content_images/cs/ipl-stadium.png'title" caption="IPLT20, el
 {{< /figure >}}
 
 {{< blockquote cite="https://www.scoopwhoop.com/sports/ms-dhoni/" by="M S Dhoni, *Jugador Internacional de críquet, ex-capitán del equipo de India, juega para Chennai Super Kings en IPL*"
-> }} No juegas para el público, juegas para el país. 
-> 
-> {{< /blockquote >}}
+>}} No juegas para el público, juegas para el país. 
+{{< /blockquote >}}
 
 ## Acerca del críquet
 

--- a/content/es/case-studies/deeplabcut-dnn.md
+++ b/content/es/case-studies/deeplabcut-dnn.md
@@ -8,9 +8,8 @@ src = '/images/content_images/cs/mice-hand.gif' title = 'Analizar movimiento de 
 {{< /figure >}}
 
 {{< blockquote cite="https://news.harvard.edu/gazette/story/newsplus/harvard-researchers-awarded-czi-open-source-award/" by="Alexander Mathis, *Profesor Asistente, Escuela Politécnica Federal de Lausana* ([EPFL](https://www.epfl.ch/en/))"
-> }} El software de código abierto está acelerando la biomedicina. DeepLabCut permite el análisis automatizado de video del comportamiento animal utilizando Aprendizaje Profundo. 
-> 
-> {{< /blockquote >}}
+>}} El software de código abierto está acelerando la biomedicina. DeepLabCut permite el análisis automatizado de video del comportamiento animal utilizando Aprendizaje Profundo. 
+{{< /blockquote >}}
 
 ## Acerca de DeepLabCut
 

--- a/content/es/case-studies/deeplabcut-dnn.md
+++ b/content/es/case-studies/deeplabcut-dnn.md
@@ -4,7 +4,11 @@ sidebar: false
 ---
 
 {{< figure >}}
-src = '/images/content_images/cs/mice-hand.gif' title = 'Analizar movimiento de las manos de los ratones usando DeepLapCut' alt = 'micehandanim' attribution = '(Fuente: www.deeplabcut.org )' attributionlink = 'http://www.mousemASElab.org/deeplabcut'
+src = '/images/content_images/cs/mice-hand.gif'
+title = 'Analizar movimiento de las manos de los ratones usando DeepLapCut'
+alt = 'micehandanim'
+attribution = '(Fuente: www.deeplabcut.org )'
+attributionlink = 'http://www.mousemASElab.org/deeplabcut'
 {{< /figure >}}
 
 {{< blockquote cite="https://news.harvard.edu/gazette/story/newsplus/harvard-researchers-awarded-czi-open-source-award/" by="Alexander Mathis, *Profesor Asistente, Escuela Politécnica Federal de Lausana* ([EPFL](https://www.epfl.ch/en/))"
@@ -18,7 +22,10 @@ src = '/images/content_images/cs/mice-hand.gif' title = 'Analizar movimiento de 
 Muchas áreas de investigación, incluyendo la neurociencia, la medicina y la biomecánica, utilizan datos para rastrear el movimiento animal. DeepLabCut ayuda a entender lo que los humanos y otros animales están haciendo, analizando las acciones que han sido grabadas en la filmación. Utilizando la automatización para tareas laboriosas de etiquetado y monitoreo, junto con el análisis de datos basado en redes neuronales profundas, DeepLabCut realiza estudios científicos que involucran la observación de animales, tales como primates, ratones, peces, moscas, etc. de manera mucho más rápida y precisa.
 
 {{< figure >}}
-src = '/images/content_images/cs/race-horse.gif' title = 'Puntos de colores rastrean las posiciones de una parte del cuerpo de un caballo de carreras' alt = 'horserideranim' attribution = '(Fuente: Mackenzie Mathis)'
+src = '/images/content_images/cs/race-horse.gif'
+title = 'Puntos de colores rastrean las posiciones de una parte del cuerpo de un caballo de carreras'
+alt = 'horserideranim'
+attribution = '(Fuente: Mackenzie Mathis)'
 {{< /figure >}}
 
 El rastreo del comportamiento no invasivo de animales de DeepLabCut por medio de la extracción de posturas de animales es crucial para propósitos científicos en dominios tales como la biomecánica, genética, etología y & neurociencia. Medir las poses de animales de manera no invasiva a partir de video - sin marcadores - en fondos que cambian dinámicamente es un desafío computacional, tanto técnicamente como en términos de necesidades de recursos y datos de entrenamiento requeridos.
@@ -49,7 +56,12 @@ Recientemente, se presentó el [modelo zoo de DeepLabCut](http://www.mousemotorl
   - graficar las inferencias utilizando herramientas de visualización integradas
 
 {{< figure >}}
-src = '/images/content_images/cs/deeplabcut-toolkit-steps.png' title = 'Pasos de estimación de la postura con DeepLabCut' alt = 'dlcsteps' align = 'center' atribución = '(Source: DeepLabCut)' attributionlink = 'https://twitter. om/DeepLabCut/status/1198046918284210176/foto/1'
+src = '/images/content_images/cs/deeplabcut-toolkit-steps.png'
+title = 'Pasos de estimación de la postura con DeepLabCut'
+alt = 'dlcsteps'
+align = 'center'
+attribution = '(Source: DeepLabCut)'
+attributionlink = 'https://twitter.com/DeepLabCut/status/1198046918284210176/photo/1'
 {{< /figure >}}
 
 ### Los Desafíos
@@ -67,7 +79,12 @@ src = '/images/content_images/cs/deeplabcut-toolkit-steps.png' title = 'Pasos de
     Por último, pero no menos importante, la manipulación de arreglos - procesamiento de grandes pilas de arreglos correspondientes a varias imágenes, tensores objetivo y puntos clave es bastante desafiante.
 
 {{< figure >}}
-src = '/images/content_images/cs/pose-estimation.png' title = 'Estimación de variedad y complejidad de postura' alt = 'challengesfig' align = 'center' atribución = '(Fuente: Mackenzie Mathis)' attributionlink = 'https://www. iorxiv.org/content/10.1101/476531v1.full.pdf'
+src = '/images/content_images/cs/pose-estimation.png'
+title = 'Estimación de variedad y complejidad de postura'
+alt = 'challengesfig'
+align = 'center'
+attribution = '(Fuente: Mackenzie Mathis)'
+attributionlink = 'https://www.iorxiv.org/content/10.1101/476531v1.full.pdf'
 {{< /figure >}}
 
 ## El Papel de NumPy para afrontar los desafíos de la estimación de postura
@@ -85,7 +102,11 @@ Las siguientes características de NumPy jugaron un papel clave en abordar el pr
 DeepLabCut utiliza las capacidades de arreglos de NumPy a lo largo del flujo de trabajo ofrecido por el conjunto de herramientas. En particular, NumPy se utiliza para muestrear diferentes fotogramas para etiquetado de anotaciones humanas, y para escribir, editar y procesar datos de anotación.  Dentro de TensorFlow, la red neuronal es entrenada por la tecnología DeepLabCut durante miles de iteraciones para predecir las anotaciones de referencia a partir de fotogramas. Para este propósito, se crean densidades objetivo (mapas de puntuación) para plantear la estimación de poses como un problema de traducción de imagen a imagen. Para hacer que las redes neuronales sean robustas, se emplea el aumento de datos, lo que requiere el cálculo de mapas de puntuación objetivo sujetos a varios pasos geométricos y de procesamiento de imágenes. Para hacer que el entrenamiento sea rápido, se aprovechan las capacidades de vectorización de NumPy. Para la inferencia, es necesario extraer las predicciones más probables de los mapas de puntuación objetivo y "vincular eficientemente las predicciones para ensamblar animales individuales".
 
 {{< figure >}}
-src = '/images/content_images/cs/deeplabcut-workflow.png' title = 'Flujo de Trabajo de DeepLabCut' alt = 'flujo de trabajo' attribution = '(Fuente: Mackenzie Mathis)' attributionlink = 'https://www.researchgate.net/figure/DeepLabCut-work-flow-The-diagram-delineates-the-work-flow-as-well-as-the-directory-and_fig1_329185962'
+src = '/images/content_images/cs/deeplabcut-workflow.png'
+title = 'Flujo de Trabajo de DeepLabCut'
+alt = 'flujo de trabajo'
+attribution = '(Fuente: Mackenzie Mathis)'
+attributionlink = 'https://www.researchgate.net/figure/DeepLabCut-work-flow-The-diagram-delineates-the-work-flow-as-well-as-the-directory-and_fig1_329185962'
 {{< /figure >}}
 
 ## Resumen
@@ -93,7 +114,9 @@ src = '/images/content_images/cs/deeplabcut-workflow.png' title = 'Flujo de Trab
 Observar y describir eficientemente el comportamiento es un punto central de la etología moderna, neurociencia, medicina y tecnología. [DeepLabCut](http://orga.cvss.cc/wp-content/uploads/2019/05/NathMathis2019.pdf) permite a los investigadores estimar la postura del sujeto, permitiéndoles de manera eficiente cuantificar el comportamiento. Con solo un pequeño conjunto de imágenes de entrenamiento, el conjunto de herramientas de Python de DeepLabCut permite entrenar una red neuronal con una precisión de etiquetado a nivel humano, expandiendo así su aplicación no solo al análisis del comportamiento en el laboratorio, sino también potencialmente en deportes, análisis de marcha, medicina y estudios de rehabilitación. Los desafíos de la combinatoria compleja y procesamiento de datos enfrentados por los algoritmos de DeepLabCut se abordan mediante el uso de las capacidades de manipulación de arreglos de NumPy.
 
 {{< figure >}}
-src = '/images/content_images/cs/numpy_dlc_benefits.png' alt = 'beneficios de NumPy' title = 'Capacidades claves utilizadas de NumPy'
+src = '/images/content_images/cs/numpy_dlc_benefits.png'
+alt = 'beneficios de NumPy'
+title = 'Capacidades claves utilizadas de NumPy'
 {{< /figure >}}
 
 [cheetah-movement]: https://www.technologynetworks.com/neuroscience/articles/interview-a-deeper-cut-into-behavior-with-mackenzie-mathis-327618

--- a/content/es/case-studies/gw-discov.md
+++ b/content/es/case-studies/gw-discov.md
@@ -4,7 +4,11 @@ sidebar: false
 ---
 
 {{< figure >}}
-src = '/images/content_images/cs/gw_sxs_image. ng' title = 'Ondas Gravitacionales' alt = 'coalescencia de un agujero negro binario generando ondas gravitacionales' attribution= '(Créditos de imagen: El proyecto Simulación de Espacio-tiempos eXtreme (SXS) en LIGO)' attributionlink = 'https://youtu. e/Zt8Z_uzG71o'
+src = '/images/content_images/cs/gw_sxs_image. ng'
+title = 'Ondas Gravitacionales'
+alt = 'coalescencia de un agujero negro binario generando ondas gravitacionales'
+attribution= '(Créditos de imagen: El proyecto Simulación de Espacio-tiempos eXtreme (SXS) en LIGO)'
+attributionlink = 'https://youtu. e/Zt8Z_uzG71o'
 {{< /figure >}}
 
 {{< blockquote cite="https://www.youtube.com/watch?v=BIvezCVcsYs" by="David Shoemaker, *Colaboración científica LIGO*" >}} El ecosistema científico de Python es una infraestructura crítica para la investigación realizada en LIGO.
@@ -40,7 +44,11 @@ El [Observatorio de Ondas Gravitacionales por Interferometría Láser (LIGO)](ht
     Una vez superados los obstáculos relacionados con comprender suficientemente bien las ecuaciones de Einstein para resolverlas utilizando supercomputadoras, el siguiente gran desafío fue hacer que los datos fueran comprensibles para el cerebro humano. La modelación de simulación, así como la detección de señales, requieren técnicas de visualización efectivas.  La visualización también desempeña un papel en otorgar más credibilidad a la relatividad numérica a los ojos de los aficionados a la ciencia pura, los cuales no le daban suficiente importancia a la relatividad numérica hasta que las imágenes y simulaciones facilitaron la comprensión de los resultados para un público más amplio. La velocidad de los cálculos complejos y la renderización, así como la re-renderización de imágenes y simulaciones utilizando los últimos datos experimentales y conocimientos, puede ser una actividad que consume mucho tiempo y que representa un desafío para los investigadores en este campo.
 
 {{< figure >}}
-src = '/images/content_images/cs/gw_strain_amplitude. ng' alt = 'amplitud de deformación de ondas gravitacionales' title = 'Amplitud de deformación de ondas gravitacionales estimada de GW150914' atribución = '(Créditos del gráfico: Observación de Ondas Gravitacionales de la Fusión de un Agujero Negro Binario, Publicación de ResearchGate)' attributionlink = 'https://www.researchgate.net/publication/293886905_Observation_of_Gravitational_Waves_from_a_Binary_Black_Hole_Merger'
+src = '/images/content_images/cs/gw_strain_amplitude. ng'
+alt = 'amplitud de deformación de ondas gravitacionales'
+title = 'Amplitud de deformación de ondas gravitacionales estimada de GW150914'
+attribution = '(Créditos del gráfico: Observación de Ondas Gravitacionales de la Fusión de un Agujero Negro Binario, Publicación de ResearchGate)'
+attributionlink = 'https://www.researchgate.net/publication/293886905_Observation_of_Gravitational_Waves_from_a_Binary_Black_Hole_Merger'
 {{< /figure >}}
 
 ## El Papel de NumPy en la Detección de Ondas Gravitacionales
@@ -59,13 +67,17 @@ NumPy, el paquete de análisis numérico estándar para Python, fue utilizado po
 * [Software clave](https://github.com/lscsoft) desarrollado en análisis de datos de Ondas Gravitacionales como, tales como [GwPy](https://gwpy.github.io/docs/stable/overview.html) y [PyCBC](https://pycbc.org) utiliza NumPy y AstroPy bajo su cubierta para proporcionar interfaces basadas en objetos a utilidades, herramientas y métodos para el estudio de datos provenientes de detectores de ondas gravitacionales.
 
 {{< figure >}}
-src = '/images/content_images/cs/gwpy-numpy-dep-graph.png' alt = 'gwpy-numpy depgraph' title = 'Gráfico de dependencias que muestra cómo depende el paquete GwPy de NumPy'
+src = '/images/content_images/cs/gwpy-numpy-dep-graph.png'
+alt = 'gwpy-numpy depgraph'
+title = 'Gráfico de dependencias que muestra cómo depende el paquete GwPy de NumPy'
 {{< /figure >}}
 
 ----
 
 {{< figure >}}
-src = '/images/content_images/cs/PyCBC-numpy-dep-graph.png' alt = 'PyCBC-numpy depgraph' title = 'Gráfico de dependencias que muestra cómo el paquete PyCBC depende de NumPy'
+src = '/images/content_images/cs/PyCBC-numpy-dep-graph.png'
+alt = 'PyCBC-numpy depgraph'
+title = 'Gráfico de dependencias que muestra cómo el paquete PyCBC depende de NumPy'
 {{< /figure >}}
 
 ## Resumen
@@ -73,5 +85,7 @@ src = '/images/content_images/cs/PyCBC-numpy-dep-graph.png' alt = 'PyCBC-numpy d
 La detección de ondas gravitacionales ha permitido a los investigadores descubrir fenómenos completamente inesperados, al tiempo que proporciona nuevos conocimientos sobre muchos de los fenómenos astrofísicos más profundos conocidos. El procesamiento de datos y la visualización de datos son pasos cruciales que ayudan a los científicos a obtener información a partir de los datos recopilados en las observaciones científicas y a comprender los resultados. Los cálculos son complejos y no pueden ser comprendidos por humanos, a menos que sean visualizados utilizando simulaciones por computador que se alimenten con datos y análisis reales observados.  NumPy, junto con otros paquetes de Python como matplotlib, pandas y scikit-learn, está [permitiendo a los investigadores](https://www.gw-openscience.org/events/GW150914/) responder preguntas complejas y descubrir nuevos horizontes en nuestra comprensión del universo.
 
 {{< figure >}}
-src = '/images/content_images/cs/numpy_gw_benefits.png' alt = 'beneficios de NumPy' title = 'Capacidades clave de NumPy utilizadas'
+src = '/images/content_images/cs/numpy_gw_benefits.png'
+alt = 'beneficios de NumPy'
+title = 'Capacidades clave de NumPy utilizadas'
 {{< /figure >}}

--- a/content/es/config.yaml
+++ b/content/es/config.yaml
@@ -1,4 +1,4 @@
-languageName: Inglés
+languageName: Español
 params:
   description: '¿Por qué NumPy? Potentes arreglos n-dimensionales. Herramientas de cálculo numérico. Interoperabilidad. Rendimiento. Código abierto.'
   navbarlogo:

--- a/content/es/user-survey-2020.md
+++ b/content/es/user-survey-2020.md
@@ -7,7 +7,7 @@ En 2020, el equipo de encuestas de NumPy, en asociación con estudiantes y profe
 
 {{< figure >}}
 src = '/surveys/NumPy_usersurvey_2020_report_cover.png' alt = 'Página de portada del informe de la encuesta de usuarios de NumPy de 2020, titulado "Encuesta de la Comunidad de NumPy 2020 - resultados"' width = '250'
-{{< /figura >}}
+{{< /figure >}}
 
 **[Descarga el informe](/surveys/NumPy_usersurvey_2020_report.pdf)** para ver a detalle los resultados de la encuesta.
 

--- a/content/es/user-survey-2020.md
+++ b/content/es/user-survey-2020.md
@@ -6,7 +6,10 @@ sidebar: false
 En 2020, el equipo de encuestas de NumPy, en asociación con estudiantes y profesores de un curso de Maestría en Metodología de Encuestas organizado conjuntamente por la Universidad de Michigan y la Universidad de Maryland, llevaron a cabo la primera encuesta oficial de la comunidad NumPy. Más de 1,200 usuarios de 75 países participaron para ayudarnos a proyectar un panorama de la comunidad NumPy y expresaron sus pensamientos sobre el futuro del proyecto.
 
 {{< figure >}}
-src = '/surveys/NumPy_usersurvey_2020_report_cover.png' alt = 'Página de portada del informe de la encuesta de usuarios de NumPy de 2020, titulado "Encuesta de la Comunidad de NumPy 2020 - resultados"' width = '250'
+src = '/surveys/NumPy_usersurvey_2020_report_cover.png'
+alt = 'Página de portada del informe de la encuesta de usuarios de NumPy de 2020'
+title = 'Encuesta de la Comunidad de NumPy 2020 - resultados'
+width = '250'
 {{< /figure >}}
 
 **[Descarga el informe](/surveys/NumPy_usersurvey_2020_report.pdf)** para ver a detalle los resultados de la encuesta.


### PR DESCRIPTION
This PR enables Spanish translations and contributes some manual fixes to  #774. The numpy.org content was translated to Spanish within Crowdin, and typically manual adjustments are needed to get the documentation to build and render correctly.

The fixes here

1. Fix block quote shortcodes within case studies markdown files which were mangled by Crowdin
2. Untranslate some shortcode names and attributes which had accidentally been translated
3. Fix formatting of some figure shortcodes within case studies and the 2020 user survey.
4. Change the language name in the drop-down from the literally translated Inglés to Español.

cc @melissawm 

Some of these things are just due to Crowdin mangling the shortcodes, but I think we should also include in the translation documentation some guidelines for translating content within and around shortcodes, (or find a way to make it so Crowdin doesn't suggest users translate things which we know shouldn't be translated).