### PR TITLE
Add teams subfolder to crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -15,3 +15,6 @@ files:
   - source: /content/en/case-studies/*.md
     translation: /content/%two_letters_code%/case-studies/%original_file_name%
     update_option: "update_as_unapproved"
+  - source: /content/en/teams/index.md
+    translation: /content/%two_letters_code%/teams/%original_file_name%
+    update_option: "update_as_unapproved"


### PR DESCRIPTION

#### Brief description of what is fixed or changed

This PR updates the crowdin.yml config file to account for the adjustment in the teams section from #734. Previously the structure was `content/xx/teams.md`, but now it is `content/xx/teams/index.md` and there are `toml` files within `content/xx/teams` for lists which are inserted into `/teams/index.md` with shortcodes.

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

