### PR TITLE
Redirect to spanish home page

### DIFF
--- a/content/es/config.yaml
+++ b/content/es/config.yaml
@@ -4,7 +4,7 @@ params:
   navbarlogo:
     image: logo.svg
     text: NumPy
-    link: /
+    link: /es/
   hero:
     #Main hero title
     title: NumPy


### PR DESCRIPTION
#### Brief description of what is fixed or changed

When navigating the Spanish version of the site, clicking the NumPy logo should bring the reader to the spanish-version home page.

Follow-up to #774 

