### PR TITLE
Fix display of ecosystem tab for Ja and Pt

### DIFF
--- a/assets/css/tabs.scss
+++ b/assets/css/tabs.scss
@@ -95,6 +95,7 @@ section.scientific-domains {
             line-height: 130%;
             margin: 0.2em 0.4em;
             flex-basis: 13%;
+            align-self: baseline;
 
             & header {
                 // FIXME: Use appropriate PST color for this header text.

--- a/content/es/tabcontents.yaml
+++ b/content/es/tabcontents.yaml
@@ -1,373 +1,275 @@
 params:
   machinelearning:
     paras:
-      - 
-        para1: NumPy constituye la base de potentes librerías de aprendizaje automático como [scikit-learn](https://scikit-learn.org) y [SciPy](https://www.scipy.org). A medida que crece el aprendizaje automático, también lo hace la lista de librerías basadas en NumPy. Las capacidades de aprendizaje profundo de [TensorFlow](https://www.tensorflow.org) tienen amplias aplicaciones&mdash; entre ellas el reconocimiento de voz e imágenes, las aplicaciones basadas en texto, el análisis de series de tiempo y la detección de vídeo. [PyTorch](https://pytorch.org), otra librería de aprendizaje profundo, es popular entre los investigadores de visión artificial y procesamiento del lenguaje natural.
+      - para1: NumPy constituye la base de potentes librerías de aprendizaje automático como [scikit-learn](https://scikit-learn.org) y [SciPy](https://www.scipy.org). A medida que crece el aprendizaje automático, también lo hace la lista de librerías basadas en NumPy. Las capacidades de aprendizaje profundo de [TensorFlow](https://www.tensorflow.org) tienen amplias aplicaciones&mdash; entre ellas el reconocimiento de voz e imágenes, las aplicaciones basadas en texto, el análisis de series de tiempo y la detección de vídeo. [PyTorch](https://pytorch.org), otra librería de aprendizaje profundo, es popular entre los investigadores de visión artificial y procesamiento del lenguaje natural.
         para2: Las técnicas estadísticas denominadas métodos [ensemble](https://towardsdatascience.com/ensemble-methods-bagging-boosting-and-stacking-c9214a10a205), como binning, bagging, stacking y boosting, se encuentran entre los algoritmos de ML implementados por herramientas como [XGBoost](https://xgboost.readthedocs.io/), [LightGBM](https://lightgbm.readthedocs.io/en/latest/) y [CatBoost](https://catboost.ai) &mdash; uno de los motores de inferencia más rápidos. [Yellowbrick](https://www.scikit-yb.org/en/latest/) y [Eli5](https://eli5.readthedocs.io/en/latest/) ofrecen visualizaciones de aprendizaje automático.
   arraylibraries:
     intro:
-      - 
-        text: La API de NumPy es el punto de partida cuando se escriben librerías para explotar hardware innovador, crear tipos de arreglos especializadas o añadir capacidades más allá de lo que NumPy proporciona.
+      - text: La API de NumPy es el punto de partida cuando se escriben librerías para explotar hardware innovador, crear tipos de arreglos especializadas o añadir capacidades más allá de lo que NumPy proporciona.
     headers:
-      - 
-        text: Librería de arreglos
-      - 
-        text: Capacidades y áreas de aplicación
+      - text: Librería de arreglos
+      - text: Capacidades y áreas de aplicación
     libraries:
-      - 
-        title: Dask
+      - title: Dask
         text: Arreglos distribuidos y paralelismo avanzado para análisis, que permiten un rendimiento a escala.
         img: /images/content_images/arlib/dask.png
         alttext: Dask
         url: https://dask.org/
-      - 
-        title: CuPy
+      - title: CuPy
         text: Librería de arreglos compatible con NumPy para cálculo acelerado en la GPU con Python.
         img: /images/content_images/arlib/cupy.png
         alttext: CuPy
         url: https://cupy.dev
-      - 
-        title: JAX
+      - title: JAX
         text: "Transformaciones componibles de programas NumPy: diferenciar, vectorizar, compilación justo-a-tiempo a GPU/TPU."
         img: /images/content_images/arlib/jax_logo_250px.png
         alttext: JAX
         url: https://jax.readthedocs.io/
-      - 
-        title: Xarray
+      - title: Xarray
         text: Arreglos multidimensionales indexados y etiquetados para análisis y visualización avanzados.
         img: /images/content_images/arlib/xarray.png
         alttext: xarray
         url: https://xarray.pydata.org/en/stable/index.html
-      - 
-        title: Sparse
+      - title: Sparse
         text: Librería de arreglos dispersos compatible con NumPy que se integra con el álgebra lineal dispersa de Dask y SciPy.
         img: /images/content_images/arlib/sparse.png
         alttext: sparse
         url: https://sparse.pydata.org/en/latest/
-      - 
-        title: PyTorch
+      - title: PyTorch
         text: Marco de aprendizaje profundo que acelera el camino desde la creación de prototipos de investigación hasta la implantación en producción.
         img: /images/content_images/arlib/pytorch-logo-dark.svg
         alttext: PyTorch
         url: https://pytorch.org/
-      - 
-        title: TensorFlow
+      - title: TensorFlow
         text: Una plataforma integral de aprendizaje automático para crear y desplegar fácilmente aplicaciones basadas en ML.
         img: /images/content_images/arlib/tensorflow-logo.svg
         alttext: TensorFlow
         url: https://www.tensorflow.org
-      - 
-        title: Arrow
+      - title: Arrow
         text: Plataforma de desarrollo multilingüe para datos y análisis columnares en memoria.
         img: /images/content_images/arlib/arrow.png
         alttext: arrow
         url: https://arrow.apache.org/
-      - 
-        title: xtensor
+      - title: xtensor
         text: Arreglos multidimensionales con difusión y computación perezosa para análisis numérico.
         img: /images/content_images/arlib/xtensor.png
         alttext: xtensor
         url: https://github.com/xtensor-stack/xtensor-python
-      - 
-        title: Awkward Array
+      - title: Awkward Array
         text: Manipular datos similares a JSON con expresiones similares a NumPy.
         img: /images/content_images/arlib/awkward.svg
         alttext: awkward
         url: https://awkward-array.org/
-      - 
-        title: uarray
+      - title: uarray
         text: Sistema de backend de Python que desacopla la API de la implementación; unumpy proporciona una API de NumPy.
         img: /images/content_images/arlib/uarray.png
         alttext: uarray
         url: https://uarray.org/en/latest/
-      - 
-        title: tensorly
+      - title: tensorly
         text: Aprendizaje tensorial, álgebra y backends para usar de manera fluida NumPy, PyTorch, TensorFlow o CuPy.
         img: /images/content_images/arlib/tensorly.png
         alttext: tensorly
         url: http://tensorly.org/stable/home.html
   scientificdomains:
     intro:
-      - 
-        text: Casi todos los científicos que trabajan en Python recurren a la potencia de NumPy.
-      - 
-        text: "NumPy aporta la potencia de cálculo de lenguajes como C y Fortran a Python, un lenguaje mucho más fácil de aprender y utilizar. Con esta potencia viene la sencillez: una solución en NumPy suele ser clara y elegante."
+      - text: Casi todos los científicos que trabajan en Python recurren a la potencia de NumPy.
+      - text: "NumPy aporta la potencia de cálculo de lenguajes como C y Fortran a Python, un lenguaje mucho más fácil de aprender y utilizar. Con esta potencia viene la sencillez: una solución en NumPy suele ser clara y elegante."
     libraries:
-      - 
-        title: Computación Cuántica
+      - title: Computación Cuántica
         alttext: Un chip para computador.
         img: /images/content_images/sc_dom_img/quantum_computing.svg
         links:
-          - 
-            url: http://qutip.org
+          - url: http://qutip.org
             label: QuTiP
-          - 
-            url: https://pyquil-docs.rigetti.com/en/stable
+          - url: https://pyquil-docs.rigetti.com/en/stable
             label: PyQuil
-          - 
-            url: https://qiskit.org
+          - url: https://qiskit.org
             label: Qiskit
-          - 
-            url: https://pennylane.ai
+          - url: https://pennylane.ai
             label: PennyLane
-      - 
-        title: Computación Estadística
+      - title: Computación Estadística
         alttext: Un gráfico lineal con la línea moviéndose hacia arriba.
         img: /images/content_images/sc_dom_img/statistical_computing.svg
         links:
-          - 
-            url: https://pandas.pydata.org/
+          - url: https://pandas.pydata.org/
             label: Pandas
-          - 
-            url: https://www.statsmodels.org/
+          - url: https://www.statsmodels.org/
             label: statsmodels
-          - 
-            url: https://xarray.pydata.org/en/stable/
+          - url: https://xarray.pydata.org/en/stable/
             label: Xarray
-          - 
-            url: https://seaborn.pydata.org/
+          - url: https://seaborn.pydata.org/
             label: Seaborn
-      - 
-        title: Procesamiento de Señales
+      - title: Procesamiento de Señales
         alttext: Un gráfico de barras con valores positivos y negativos.
         img: /images/content_images/sc_dom_img/signal_processing.svg
         links:
-          - 
-            url: https://www.scipy.org/
+          - url: https://www.scipy.org/
             label: SciPy
-          - 
-            url: https://pywavelets.readthedocs.io/
+          - url: https://pywavelets.readthedocs.io/
             label: PyWavelets
-          - 
-            url: https://python-control.org/
+          - url: https://python-control.org/
             label: python-control
-          - 
-            url: https://hyperspy.org/
+          - url: https://hyperspy.org/
             label: HiperSpy
-      - 
-        title: Procesamiento de Imágenes
+      - title: Procesamiento de Imágenes
         alttext: Una fotografía de las montañas.
         img: /images/content_images/sc_dom_img/image_processing.svg
         links:
-          - 
-            url: https://scikit-image.org/
+          - url: https://scikit-image.org/
             label: Scikit-image
-          - 
-            url: https://opencv.org/
+          - url: https://opencv.org/
             label: OpenCV
-          - 
-            url: https://mahotas.rtfd.io/
+          - url: https://mahotas.rtfd.io/
             label: Mahotas
-      - 
-        title: Grafos y Redes
+      - title: Grafos y Redes
         alttext: Un grafo simple.
         img: /images/content_images/sc_dom_img/sd6.svg
         links:
-          - 
-            url: https://networkx.org/
+          - url: https://networkx.org/
             label: NetworkX
-          - 
-            url: https://graph-tool.skewed.de/
+          - url: https://graph-tool.skewed.de/
             label: graph-tool
-          - 
-            url: https://igraph.org/python/
+          - url: https://igraph.org/python/
             label: igraph
-          - 
-            url: https://pygsp.rtfd.io/
+          - url: https://pygsp.rtfd.io/
             label: PyGSP
-      - 
-        title: Astronomía
+      - title: Astronomía
         alttext: Un telescopio.
         img: /images/content_images/sc_dom_img/astronomy_processes.svg
         links:
-          - 
-            url: https://www.astropy.org/
+          - url: https://www.astropy.org/
             label: AstroPy
-          - 
-            url: https://sunpy.org/
+          - url: https://sunpy.org/
             label: SunPy
-          - 
-            url: https://spacepy.github.io/
+          - url: https://spacepy.github.io/
             label: SpacePy
-      - 
-        title: Psicología Cognitiva
+      - title: Psicología Cognitiva
         alttext: Una cabeza humana con engranajes.
         img: /images/content_images/sc_dom_img/cognitive_psychology.svg
         links:
-          - 
-            url: https://www.psychopy.org/
+          - url: https://www.psychopy.org/
             label: PsychoPy
-      - 
-        title: Bioinformática
+      - title: Bioinformática
         alttext: Una hebra de ADN.
         img: /images/content_images/sc_dom_img/bioinformatics.svg
         links:
-          - 
-            url: https://biopython.org/
+          - url: https://biopython.org/
             label: BioPython
-          - 
-            url: http://scikit-bio.org/
+          - url: http://scikit-bio.org/
             label: Scikit-Bio
-          - 
-            url: https://github.com/openvax/pyensembl
+          - url: https://github.com/openvax/pyensembl
             label: PyEnsembl
-          - 
-            url: http://etetoolkit.org/
+          - url: http://etetoolkit.org/
             label: ETE
-      - 
-        title: Inferencia Bayesiana
+      - title: Inferencia Bayesiana
         alttext: Un gráfico con una curva en forma de campanas.
         img: /images/content_images/sc_dom_img/bayesian_inference.svg
         links:
-          - 
-            url: https://pystan.readthedocs.io/en/latest/
+          - url: https://pystan.readthedocs.io/en/latest/
             label: PyStan
-          - 
-            url: https://docs.pymc.io/
+          - url: https://docs.pymc.io/
             label: PyMC3
-          - 
-            url: https://arviz-devs.github.io/arviz/
+          - url: https://arviz-devs.github.io/arviz/
             label: ArviZ
-          - 
-            url: https://emcee.readthedocs.io/
+          - url: https://emcee.readthedocs.io/
             label: emcee
-      - 
-        title: Análisis Matemático
+      - title: Análisis Matemático
         alttext: Cuatro símbolos matemáticos.
         img: /images/content_images/sc_dom_img/mathematical_analysis.svg
         links:
-          - 
-            url: https://www.scipy.org/
+          - url: https://www.scipy.org/
             label: SciPy
-          - 
-            url: https://www.sympy.org/
+          - url: https://www.sympy.org/
             label: SymPy
-          - 
-            url: https://www.cvxpy.org/
+          - url: https://www.cvxpy.org/
             label: cvxpy
-          - 
-            url: https://fenicsproject.org/
+          - url: https://fenicsproject.org/
             label: FEniCS
-      - 
-        title: Química
+      - title: Química
         alttext: Un tubo de ensayo.
         img: /images/content_images/sc_dom_img/chemistry.svg
         links:
-          - 
-            url: https://cantera.org/
+          - url: https://cantera.org/
             label: Cantera
-          - 
-            url: https://www.mdanalysis.org/
+          - url: https://www.mdanalysis.org/
             label: MDAnalysis
-          - 
-            url: https://github.com/rdkit/rdkit
+          - url: https://github.com/rdkit/rdkit
             label: RDKit
-          - 
-            url: https://www.pybamm.org/
+          - url: https://www.pybamm.org/
             label: PyBaMM
-      - 
-        title: Geociencia
+      - title: Geociencia
         alttext: La Tierra.
         img: /images/content_images/sc_dom_img/geoscience.svg
         links:
-          - 
-            url: https://pangeo.io/
+          - url: https://pangeo.io/
             label: Pangeo
-          - 
-            url: https://simpeg.xyz/
+          - url: https://simpeg.xyz/
             label: Simpeg
-          - 
-            url: https://github.com/obspy/obspy/wiki
+          - url: https://github.com/obspy/obspy/wiki
             label: ObsPy
-          - 
-            url: https://www.fatiando.org/
+          - url: https://www.fatiando.org/
             label: Fatiando a Terra
-      - 
-        title: Procesamiento Geográfico
+      - title: Procesamiento Geográfico
         alttext: Un mapa.
         img: /images/content_images/sc_dom_img/GIS.svg
         links:
-          - 
-            url: https://shapely.readthedocs.io/
+          - url: https://shapely.readthedocs.io/
             label: Shapely
-          - 
-            url: https://geopandas.org/
+          - url: https://geopandas.org/
             label: GeoPandas
-          - 
-            url: https://python-visualization.github.io/folium
+          - url: https://python-visualization.github.io/folium
             label: Folium
-      - 
-        title: Arquitectura e Ingeniería
+      - title: Arquitectura e Ingeniería
         alttext: Una placa de desarrollo de microprocesadores.
         img: /images/content_images/sc_dom_img/robotics.svg
         links:
-          - 
-            url: https://compas.dev/
+          - url: https://compas.dev/
             label: COMPAS
-          - 
-            url: https://cityenergyanalyst.com/
+          - url: https://cityenergyanalyst.com/
             label: City Energy Analyst - Analista de Energía de Ciudad
-          - 
-            url: https://nortikin.github.io/sverchok/
+          - url: https://nortikin.github.io/sverchok/
             label: Sverchok
   datascience:
     intro: "NumPy es el núcleo de un rico ecosistema de librerías de ciencia de datos. Un flujo de trabajo exploratorio típico de ciencia de datos podría verse así:"
     image1:
-      - 
-        img: /images/content_images/ds-landscape.png
+      - img: /images/content_images/ds-landscape.png
         alttext: Diagrama de las librerías de Python. Las cinco categorías son "Extraer, Transformar, Cargar", "Exploración de Datos", "Modelado de Datos", "Evaluación de Datos" y "Presentación de Datos".
     image2:
-      - 
-        img: /images/content_images/data-science.png
+      - img: /images/content_images/data-science.png
         alttext: Diagrama de tres círculos superpuestos. Los círculos se denominan "Matemáticas", "Ciencias de la Computación" y "Conocimientos Especializados". En el centro del diagrama, con los tres círculos superpuestos, hay un área denominada "Ciencia de datos".
     examples:
-      - 
-        text: "<b>Extraer, Transformar, Cargar: </b>[Pandas](https://pandas.pydata.org), [Intake](https://intake.readthedocs.io), [PyJanitor](https://pyjanitor.readthedocs.io/)"
-      - 
-        text: "<b>Análisis Exploratorio: </b>[Jupyter](https://jupyter.org), [Seaborn](https://seaborn.pydata.org), [Matplotlib](https://matplotlib.org), [Altair](https://altair-viz.github.io)"
-      - 
-        text: "<b>Modelado y evaluación: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC3](https://docs.pymc.io), [spaCy](https://spacy.io)"
-      - 
-        text: "<b>Informes en un panel de control: </b>[Dash](https://plotly.com/dash), [Panel](https://panel.holoviz.org), [Voila](https://github.com/voila-dashboards/voila)"
+      - text: "<b>Extraer, Transformar, Cargar: </b>[Pandas](https://pandas.pydata.org), [Intake](https://intake.readthedocs.io), [PyJanitor](https://pyjanitor.readthedocs.io/)"
+      - text: "<b>Análisis Exploratorio: </b>[Jupyter](https://jupyter.org), [Seaborn](https://seaborn.pydata.org), [Matplotlib](https://matplotlib.org), [Altair](https://altair-viz.github.io)"
+      - text: "<b>Modelado y evaluación: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC3](https://docs.pymc.io), [spaCy](https://spacy.io)"
+      - text: "<b>Informes en un panel de control: </b>[Dash](https://plotly.com/dash), [Panel](https://panel.holoviz.org), [Voila](https://github.com/voila-dashboards/voila)"
     content:
-      - 
-        text: Para grandes volúmenes de datos, [Dask](https://dask.org) y [Ray](https://ray.io/) están diseñados para escalarse. Las implementaciones estables se basan en el versionado de datos ([DVC](https://dvc.org)), rastreo de experimentos ([MLFlow](https://mlflow.org)), y automatización del flujo de trabajo ([Airflow](https://airflow.apache.org), [Dagster](https://dagster.io) y [Prefect](https://www.prefect.io)).
+      - text: Para grandes volúmenes de datos, [Dask](https://dask.org) y [Ray](https://ray.io/) están diseñados para escalarse. Las implementaciones estables se basan en el versionado de datos ([DVC](https://dvc.org)), rastreo de experimentos ([MLFlow](https://mlflow.org)), y automatización del flujo de trabajo ([Airflow](https://airflow.apache.org), [Dagster](https://dagster.io) y [Prefect](https://www.prefect.io)).
   visualization:
     images:
-      - 
-        url: https://www.fusioncharts.com/blog/best-python-data-visualization-libraries
+      - url: https://www.fusioncharts.com/blog/best-python-data-visualization-libraries
         img: /images/content_images/v_matplotlib.png
         alttext: Un diagrama de flujo hecho en matplotlib
-      - 
-        url: https://github.com/yhat/ggpy
+      - url: https://github.com/yhat/ggpy
         img: /images/content_images/v_ggpy.png
         alttext: Un diagrama de dispersión hecho en ggpy
-      - 
-        url: https://www.journaldev.com/19692/python-plotly-tutorial
+      - url: https://www.journaldev.com/19692/python-plotly-tutorial
         img: /images/content_images/v_plotly.png
         alttext: Un diagrama de caja hecho en plotly
-      - 
-        url: https://altair-viz.github.io/gallery/streamgraph.html
+      - url: https://altair-viz.github.io/gallery/streamgraph.html
         img: /images/content_images/v_altair.png
         alttext: Un diagrama de flujo hecho en altair
-      - 
-        url: https://seaborn.pydata.org
+      - url: https://seaborn.pydata.org
         img: /images/content_images/v_seaborn.png
         alttext: Un gráfico de pares de dos tipos de gráficos, un gráfico de trazado y un gráfico de frecuencias hecho en seaborn
-      - 
-        url: https://docs.pyvista.org/examples/index.html
+      - url: https://docs.pyvista.org/examples/index.html
         img: /images/content_images/v_pyvista.png
         alttext: Un renderizado de volumen 3D realizado en PyVista.
-      - 
-        url: https://napari.org
+      - url: https://napari.org
         img: /images/content_images/v_napari.png
         alttext: Una imagen multidimensional hecha en napari.
-      - 
-        url: https://vispy.org/gallery/index.html
+      - url: https://vispy.org/gallery/index.html
         img: /images/content_images/v_vispy.png
         alttext: Un diagrama de Voronoi hecho en vispy.
     content:
-      - 
-        text: NumPy es un componente esencial en el floreciente [panorama de visualización de Python](https://pyviz.org/overviews/index.html), que incluye [Matplotlib](https://matplotlib.org), [Seaborn](https://seaborn.pydata.org), [Plotly](https://plot.ly), [Altair](https://altair-viz.github.io), [Bokeh](https://docs.bokeh.org/en/latest/), [Holoviz](https://holoviz.org), [Vispy](http://vispy.org), [Napari](https://github.com/napari/napari), y [PyVista](https://github.com/pyvista/pyvista), por nombrar algunos.
-      - 
-        text: El procesamiento acelerado de arreglos de gran tamaño de NumPy permite a los investigadores visualizar conjuntos de datos mucho mayores a los que el Python nativo podría manejar.
+      - text: NumPy es un componente esencial en el floreciente [panorama de visualización de Python](https://pyviz.org/overviews/index.html), que incluye [Matplotlib](https://matplotlib.org), [Seaborn](https://seaborn.pydata.org), [Plotly](https://plot.ly), [Altair](https://altair-viz.github.io), [Bokeh](https://docs.bokeh.org/en/latest/), [Holoviz](https://holoviz.org), [Vispy](http://vispy.org), [Napari](https://github.com/napari/napari), y [PyVista](https://github.com/pyvista/pyvista), por nombrar algunos.
+      - text: El procesamiento acelerado de arreglos de gran tamaño de NumPy permite a los investigadores visualizar conjuntos de datos mucho mayores a los que el Python nativo podría manejar.

--- a/content/ja/tabcontents.yaml
+++ b/content/ja/tabcontents.yaml
@@ -1,161 +1,239 @@
 params:
   machinelearning:
     paras:
-      - 
-        para1: NumPyは、[scikit-learn](https://scikit-learn.org)や[SciPy](https://www.scipy.org)のような強力な機械学習ライブラリの基礎を形成しています。機械学習の技術分野が成長するにつれ、NumPyをベースにしたライブラリの数も増えています。[TensorFlow](https://www.tensorflow.org)の深層学習機能は、音声認識や画像認識、テキストベースのアプリケーション、時系列分析、動画検出など、幅広い応用用途があります。[PyTorch](https://pytorch.org)も、コンピュータビジョンや自然言語処理の研究者に人気のある深層学習ライブラリです。[MXNet](https://github.com/apache/incubator-mxnet)もAIパッケージの一つで、深層学習の設計図やテンプレート機能を提供しています。
+      - para1: NumPyは、[scikit-learn](https://scikit-learn.org)や[SciPy](https://www.scipy.org)のような強力な機械学習ライブラリの基礎を形成しています。機械学習の技術分野が成長するにつれ、NumPyをベースにしたライブラリの数も増えています。[TensorFlow](https://www.tensorflow.org)の深層学習機能は、音声認識や画像認識、テキストベースのアプリケーション、時系列分析、動画検出など、幅広い応用用途があります。[PyTorch](https://pytorch.org)も、コンピュータビジョンや自然言語処理の研究者に人気のある深層学習ライブラリです。[MXNet](https://github.com/apache/incubator-mxnet)もAIパッケージの一つで、深層学習の設計図やテンプレート機能を提供しています。
         para2: '[ensemble](https://towardsdatascience.com/ensemble-methods-bagging-boosting-and-stacking-c9214a10a205)法と呼ばれる統計的手法であるビンニング、バギング、スタッキングや、[XGBoost](https://github.com/dmlc/xgboost)、[LightGBM](https://lightgbm.readthedocs.io/en/latest/)、[CatBoost](https://catboost.ai)などのツールで実装されているブースティングなどは、機械学習アルゴリズムの一つであり、最速の推論エンジンの一つです。[Yellowbrick](https://www.scikit-yb.org/en/latest/)や[Eli5](https://eli5.readthedocs.io/en/latest/)は機械学習の可視化機能を提供しています。'
   arraylibraries:
     intro:
-      - 
-        text: NumPyのAPIは、革新的なハードウェアを利用したり、特殊な配列タイプを作成したり、NumPyが提供する以上の機能を追加するためにライブラリを作成する際の基礎となります。
+      - text: NumPyのAPIは、革新的なハードウェアを利用したり、特殊な配列タイプを作成したり、NumPyが提供する以上の機能を追加するためにライブラリを作成する際の基礎となります。
     headers:
-      - 
-        text: 配列ライブラリ
-      - 
-        text: 機能と応用分野
+      - text: 配列ライブラリ
+      - text: 機能と応用分野
     libraries:
-      - 
-        title: Dask
+      - title: Dask
         text: 分析用の分散配列と高度な並列処理により、大規模な処理を可能にします。
         img: /images/content_images/arlib/dask.png
         alttext: Dask
         url: https://dask.org/
-      - 
-        title: CuPy
+      - title: CuPy
         text: Python を使用した GPUによる高速計算用のNumPy互換配列ライブラリ
         img: /images/content_images/arlib/cupy.png
         alttext: CuPy
         url: https://cupy.chainer.org
-      - 
-        title: JAX
+      - title: JAX
         text: "NumPyコードの合成可能な変換ライブラリ: 微分、ベクトル化、GPU/TPUへのジャストインタイムコンパイル"
         img: /images/content_images/arlib/jax_logo_250px.png
         alttext: JAX
         url: https://github.com/google/jax
-      - 
-        title: Xarray
+      - title: Xarray
         text: 高度な分析と視覚化のためのラベルとインデックス付き多次元配列
         img: /images/content_images/arlib/xarray.png
         alttext: xarray
         url: https://xarray.pydata.org/en/stable/index.html
-      - 
-        title: Sparse
+      - title: Sparse
         text: Dask と SciPy の疎行列の線形代数ライブラリを統合した、Numpy 互換の疎行列ライブラリ
         img: /images/content_images/arlib/sparse.png
         alttext: sparse
         url: https://sparse.pydata.org/en/latest/
-      - 
-        title: PyTorch
+      - title: PyTorch
         text: 研究用のプロトタイピングから本番運用への展開を加速させる、深層学習フレームワーク
         img: /images/content_images/arlib/pytorch-logo-dark.svg
         alttext: PyTorch
         url: https://pytorch.org/
-      - 
-        title: TensorFlow
+      - title: TensorFlow
         text: 機械学習を利用したアプリケーションを簡単に構築・展開するための、エンド・ツー・エンドの機械学習プラットフォーム
         img: /images/content_images/arlib/tensorflow-logo.svg
         alttext: TensorFlow
         url: https://www.tensorflow.org
-      - 
-        title: MXNet
+      - title: MXNet
         text: 柔軟や研究用のプロトタイピングから、実際の運用まで利用可能な深層学習フレームワーク
         img: /images/content_images/arlib/mxnet_logo.png
         alttext: MXNet
         url: https://mxnet.apache.org/
-      - 
-        title: Arrow
+      - title: Arrow
         text: 列型のインメモリーデータやその分析のための、複数の言語に対応した開発プラットフォーム
         img: /images/content_images/arlib/arrow.png
         alttext: arrow
         url: https://github.com/apache/arrow
-      - 
-        title: xtensor
+      - title: xtensor
         text: 数値解析のためのブロードキャスティングと遅延計算を備えた多次元配列
         img: /images/content_images/arlib/xtensor.png
         alttext: xtensor
         url: https://github.com/xtensor-stack/xtensor-python
-      - 
-        title: Awkward
+      - title: Awkward
         text: Numpy のような イディオムを使って JSON のようなデータを操作するライブラリ
         img: /images/content_images/arlib/xnd.png
         alttext: awkward
         url: https://awkward-array.org/
-      - 
-        title: uarray
+      - title: uarray
         text: APIを実装から切り離すPythonバックエンドシステム (unumpyはNumPy APIを提供しています)
         img: /images/content_images/arlib/uarray.png
         alttext: uarray
         url: https://uarray.org/en/latest/
-      - 
-        title: tensorly
+      - title: tensorly
         text: Numpy、MXNet、PyTorch、TensorFlowまたはCupyをシームレスに使用するための、テンソル学習、テンソル代数、およびそれらのテンソル計算のためのバックエンド
         img: /images/content_images/arlib/tensorly.png
         alttext: tensorly
         url: http://tensorly.org/stable/home.html
   scientificdomains:
     intro:
-      - 
-        text: Pythonを使って働くほとんどの科学者はNumPyの力を利用しています。
-      - 
-        text: "Numpy は、 C や Fortran のような言語の計算パフォーマンスを、Pythonにもたらします。 このパワーはNumPyのシンプルさから来ており、NumPyによるソリューションの多くは明確でエレガントになります。"
-    librariesrow1:
-      - 
-        title: 量子コンピューティング
+      - text: Pythonを使って働くほとんどの科学者はNumPyの力を利用しています。
+      - text: "Numpy は、 C や Fortran のような言語の計算パフォーマンスを、Pythonにもたらします。 このパワーはNumPyのシンプルさから来ており、NumPyによるソリューションの多くは明確でエレガントになります。"
+    libraries:
+      - title: 量子コンピューティング
         alttext: コンピューターチップ
         img: /images/content_images/sc_dom_img/quantum_computing.svg
-      - 
-        title: 統計コンピューティング
+        links:
+          - url: http://qutip.org
+            label: QuTiP
+          - url: https://pyquil-docs.rigetti.com/en/stable
+            label: PyQuil
+          - url: https://qiskit.org
+            label: Qiskit
+          - url: https://pennylane.ai
+            label: PennyLane
+      - title: 統計コンピューティング
         alttext: 線グラフで、グラフが上に移動します。
         img: /images/content_images/sc_dom_img/statistical_computing.svg
-      - 
-        title: 信号処理
+        links:
+          - url: https://pandas.pydata.org/
+            label: Pandas
+          - url: https://www.statsmodels.org/
+            label: statsmodels
+          - url: https://xarray.pydata.org/en/stable/
+            label: Xarray
+          - url: https://seaborn.pydata.org/
+            label: Seaborn
+      - title: 信号処理
         alttext: 正と負の値を持つ棒グラフ。
         img: /images/content_images/sc_dom_img/signal_processing.svg
-      - 
-        title: 画像処理
+        links:
+          - url: https://www.scipy.org/
+            label: SciPy
+          - url: https://pywavelets.readthedocs.io/
+            label: PyWavelets
+          - url: https://python-control.org/
+            label: python-control
+          - url: https://hyperspy.org/
+            label: HiperSpy
+      - title: 画像処理
         alttext: 山々の写真
         img: /images/content_images/sc_dom_img/image_processing.svg
-      - 
-        title: グラフとネットワーク
+        links:
+          - url: https://scikit-image.org/
+            label: Scikit-image
+          - url: https://opencv.org/
+            label: OpenCV
+          - url: https://mahotas.rtfd.io/
+            label: Mahotas
+      - title: グラフとネットワーク
         alttext: シンプルなグラフ
         img: /images/content_images/sc_dom_img/sd6.svg
-      - 
-        title: 天文学
+        links:
+          - url: https://networkx.org/
+            label: NetworkX
+          - url: https://graph-tool.skewed.de/
+            label: graph-tool
+          - url: https://igraph.org/python/
+            label: igraph
+          - url: https://pygsp.rtfd.io/
+            label: PyGSP
+      - title: 天文学
         alttext: 望遠鏡
         img: /images/content_images/sc_dom_img/astronomy_processes.svg
-      - 
-        title: 認知心理学
+        links:
+          - url: https://www.astropy.org/
+            label: AstroPy
+          - url: https://sunpy.org/
+            label: SunPy
+          - url: https://spacepy.github.io/
+            label: SpacePy
+      - title: 認知心理学
         alttext: ギアをつけた人間の頭部
         img: /images/content_images/sc_dom_img/cognitive_psychology.svg
-    librariesrow2:
-      - 
-        title: 生命情報科学
+        links:
+          - url: https://www.psychopy.org/
+            label: PsychoPy
+      - title: 生命情報科学
         alttext: DNAの鎖
         img: /images/content_images/sc_dom_img/bioinformatics.svg
-      - 
-        title: ベイズ推論
+        links:
+          - url: https://biopython.org/
+            label: BioPython
+          - url: http://scikit-bio.org/
+            label: Scikit-Bio
+          - url: https://github.com/openvax/pyensembl
+            label: PyEnsembl
+          - url: http://etetoolkit.org/
+            label: ETE
+      - title: ベイズ推論
         alttext: 鐘形の曲線のグラフ
         img: /images/content_images/sc_dom_img/bayesian_inference.svg
-      - 
-        title: 数学的分析
+        links:
+          - url: https://pystan.readthedocs.io/en/latest/
+            label: PyStan
+          - url: https://docs.pymc.io/
+            label: PyMC3
+          - url: https://arviz-devs.github.io/arviz/
+            label: ArviZ
+          - url: https://emcee.readthedocs.io/
+            label: emcee
+      - title: 数学的分析
         alttext: ４つの数学記号
         img: /images/content_images/sc_dom_img/mathematical_analysis.svg
-      - 
-        title: 化学
+        links:
+          - url: https://www.scipy.org/
+            label: SciPy
+          - url: https://www.sympy.org/
+            label: SymPy
+          - url: https://www.cvxpy.org/
+            label: cvxpy
+          - url: https://fenicsproject.org/
+            label: FEniCS
+      - title: 化学
         alttext: 試験管
         img: /images/content_images/sc_dom_img/chemistry.svg
-      - 
-        title: 地球科学
+        links:
+          - url: https://cantera.org/
+            label: Cantera
+          - url: https://www.mdanalysis.org/
+            label: MDAnalysis
+          - url: https://github.com/rdkit/rdkit
+            label: RDKit
+          - url: https://www.pybamm.org/
+            label: PyBaMM
+      - title: 地球科学
         alttext: 地球
         img: /images/content_images/sc_dom_img/geoscience.svg
-      - 
-        title: 地理情報処理
+        links:
+          - url: https://pangeo.io/
+            label: Pangeo
+          - url: https://simpeg.xyz/
+            label: Simpeg
+          - url: https://github.com/obspy/obspy/wiki
+            label: ObsPy
+          - url: https://www.fatiando.org/
+            label: Fatiando a Terra
+      - title: 地理情報処理
         alttext: 地図
         img: /images/content_images/sc_dom_img/GIS.svg
-      - 
-        title: アーキテクチャとエンジニアリング
+        links:
+          - url: https://shapely.readthedocs.io/
+            label: Shapely
+          - url: https://geopandas.org/
+            label: GeoPandas
+          - url: https://python-visualization.github.io/folium
+            label: Folium
+      - title: アーキテクチャとエンジニアリング
         alttext: マイクロプロセッサ開発ボード
         img: /images/content_images/sc_dom_img/robotics.svg
+        links:
+          - url: https://compas.dev/
+            label: COMPAS
+          - url: https://cityenergyanalyst.com/
+            label: City Energy Analyst - Analista de Energía de Ciudad
+          - url: https://nortikin.github.io/sverchok/
+            label: Sverchok
   datascience:
     intro: "Numpy は豊富なデータサイエンスライブラリのエコシステムの中核にあります。一般的なデータサイエンスのワークフローは次のようになります。"
     image1:

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -1,219 +1,280 @@
 params:
   machinelearning:
     paras:
-      - 
-        para1: O NumPy forma a base de bibliotecas de aprendizagem de máquina poderosas como [scikit-learn](https://scikit-learn.org) e [SciPy](https://www.scipy.org). À medida que a disciplina de aprendizagem de máquina cresce, a lista de bibliotecas construidas a partir do NumPy também cresce. As funcionalidades de deep learning do [TensorFlow](https://www.tensorflow.org) tem diversas aplicações &mdash; entre elas, reconhecimento de imagem e de fala, aplicações baseadas em texto, análise de séries temporais, e detecção de vídeo. O [PyTorch](https://pytorch.org), outra biblioteca de deep learning, é popular entre pesquisadores em visão computacional e processamento de linguagem natural. O [MXNet](https://github.com/apache/incubator-mxnet) é outro pacote de IA, que fornece templates e protótipos para deep learning.
+      - para1: O NumPy forma a base de bibliotecas de aprendizagem de máquina poderosas como [scikit-learn](https://scikit-learn.org) e [SciPy](https://www.scipy.org). À medida que a disciplina de aprendizagem de máquina cresce, a lista de bibliotecas construidas a partir do NumPy também cresce. As funcionalidades de deep learning do [TensorFlow](https://www.tensorflow.org) tem diversas aplicações &mdash; entre elas, reconhecimento de imagem e de fala, aplicações baseadas em texto, análise de séries temporais, e detecção de vídeo. O [PyTorch](https://pytorch.org), outra biblioteca de deep learning, é popular entre pesquisadores em visão computacional e processamento de linguagem natural. O [MXNet](https://github.com/apache/incubator-mxnet) é outro pacote de IA, que fornece templates e protótipos para deep learning.
         para2: Técnicas estatísticas chamadas métodos de [ensemble](https://towardsdatascience.com/ensemble-methods-bagging-boosting-and-stacking-c9214a10a205) tais como binning, bagging, stacking, e boosting estão entre os algoritmos de ML implementados por ferramentas tais como [XGBoost](https://github.com/dmlc/xgboost), [LightGBM](https://lightgbm.readthedocs.io/en/latest/), e [CatBoost](https://catboost.ai) &mdash; um dos motores de inferência mais rápidos. [Yellowbrick](https://www.scikit-yb.org/en/latest/) e [Eli5](https://eli5.readthedocs.io/en/latest/) oferecem visualizações para aprendizagem de máquina.
   arraylibraries:
     intro:
-      - 
-        text: A API do NumPy é o ponto de partida quando bibliotecas são escritas para explorar hardware inovador, criar tipos de arrays especializados, ou adicionar capacidades além do que o NumPy fornece.
+      - text: A API do NumPy é o ponto de partida quando bibliotecas são escritas para explorar hardware inovador, criar tipos de arrays especializados, ou adicionar capacidades além do que o NumPy fornece.
     headers:
-      - 
-        text: Biblioteca de Arrays
-      - 
-        text: Recursos e áreas de aplicação
+      - text: Biblioteca de Arrays
+      - text: Recursos e áreas de aplicação
     libraries:
-      - 
-        title: Dask
+      - title: Dask
         text: Arrays distribuídas e paralelismo avançado para análise, permitindo desempenho em escala.
         img: /images/content_images/arlib/dask.png
         alttext: Dask
         url: https://dask.org/
-      - 
-        title: CuPy
+      - title: CuPy
         text: Biblioteca de matriz compatível com NumPy para computação acelerada pela GPU com Python.
         img: /images/content_images/arlib/cupy.png
         alttext: CuPy
         url: https://cupy.chainer.org
-      - 
-        title: JAX
+      - title: JAX
         text: "Transformações combináveis de programas NumPy: vetorização, compilação just-in-time para GPU/TPU."
         img: /images/content_images/arlib/jax_logo_250px.png
         alttext: JAX
         url: https://github.com/google/jax
-      - 
-        title: Xarray
+      - title: Xarray
         text: Arrays multidimensionais rotuladas e indexadas para análise e visualização avançadas
         img: /images/content_images/arlib/xarray.png
         alttext: xarray
         url: https://xarray.pydata.org/en/stable/index.html
-      - 
-        title: Sparse
+      - title: Sparse
         text: Biblioteca de arrays compatíveis com o NumPy que pode ser integrada com Dask e álgebra linear esparsa da SciPy.
         img: /images/content_images/arlib/sparse.png
         alttext: sparse
         url: https://sparse.pydata.org/en/latest/
-      - 
-        title: PyTorch
+      - title: PyTorch
         text: Framework de deep learning que acelera o caminho entre prototipação de pesquisa e colocação em produção.
         img: /images/content_images/arlib/pytorch-logo-dark.svg
         alttext: PyTorch
         url: https://pytorch.org/
-      - 
-        title: TensorFlow
+      - title: TensorFlow
         text: Uma plataforma completa para aprendizagem de máquina que permite construir e colocar em produção aplicações usando ML facilmente.
         img: /images/content_images/arlib/tensorflow-logo.svg
         alttext: TensorFlow
         url: https://www.tensorflow.org
-      - 
-        title: MXNet
+      - title: MXNet
         text: Framework de deep learning voltado para flexibilizar prototipação em pesquisa e produção.
         img: /images/content_images/arlib/mxnet_logo.png
         alttext: MXNet
         url: https://mxnet.apache.org/
-      - 
-        title: Arrow
+      - title: Arrow
         text: Uma plataforma de desenvolvimento multi-linguagens para dados e análise para dados armazenados em colunas na memória.
         img: /images/content_images/arlib/arrow.png
         alttext: arrow
         url: https://github.com/apache/arrow
-      - 
-        title: xtensor
+      - title: xtensor
         text: Arrays multidimensionais com broadcasting e avaliação preguiçosa (lazy computing) para análise numérica.
         img: /images/content_images/arlib/xtensor.png
         alttext: xtensor
         url: https://github.com/xtensor-stack/xtensor-python
-      - 
-        title: Awkward Array
+      - title: Awkward Array
         text: Manipulação de dados JSON-like com sintaxe NumPy-like.
         img: /images/content_images/arlib/awkward.svg
         alttext: awkward
         url: https://awkward-array.org/
-      - 
-        title: uarray
+      - title: uarray
         text: Sistema de backend Python que dissocia a API da implementação; unumpy fornece uma API NumPy.
         img: /images/content_images/arlib/uarray.png
         alttext: uarray
         url: https://uarray.org/en/latest/
-      - 
-        title: tensorly
+      - title: tensorly
         text: Ferramentas para aprendizagem com tensores, algebra e backends para usar NumPy, MXNet, PyTorch, TensorFlow ou CuPy sem esforço.
         img: /images/content_images/arlib/tensorly.png
         alttext: tensorly
         url: http://tensorly.org/stable/home.html
   scientificdomains:
     intro:
-      - 
-        text: Quase todos os cientistas que trabalham em Python se baseiam na potência do NumPy.
-      - 
-        text: "NumPy traz o poder computacional de linguagens como C e Fortran para Python, uma linguagem muito mais fácil de aprender e usar. Com esse poder vem a simplicidade: uma solução no NumPy é frequentemente clara e elegante."
-    librariesrow1:
-      - 
-        title: Computação quântica
+      - text: Quase todos os cientistas que trabalham em Python se baseiam na potência do NumPy.
+      - text: "NumPy traz o poder computacional de linguagens como C e Fortran para Python, uma linguagem muito mais fácil de aprender e usar. Com esse poder vem a simplicidade: uma solução no NumPy é frequentemente clara e elegante."
+    libraries:
+      - title: Computação quântica
         alttext: Um chip de computador.
         img: /images/content_images/sc_dom_img/quantum_computing.svg
-      - 
-        title: Computação estatística
+        links:
+          - url: http://qutip.org
+            label: QuTiP
+          - url: https://pyquil-docs.rigetti.com/en/stable
+            label: PyQuil
+          - url: https://qiskit.org
+            label: Qiskit
+          - url: https://pennylane.ai
+            label: PennyLane
+      - title: Computação estatística
         alttext: Um gráfico com uma linha em movimento para cima.
         img: /images/content_images/sc_dom_img/statistical_computing.svg
-      - 
-        title: Processamento de sinais
+        links:
+          - url: https://pandas.pydata.org/
+            label: Pandas
+          - url: https://www.statsmodels.org/
+            label: statsmodels
+          - url: https://xarray.pydata.org/en/stable/
+            label: Xarray
+          - url: https://seaborn.pydata.org/
+            label: Seaborn
+      - title: Processamento de sinais
         alttext: Um gráfico de barras com valores positivos e negativos.
         img: /images/content_images/sc_dom_img/signal_processing.svg
-      - 
-        title: Processamento de imagens
+        links:
+          - url: https://www.scipy.org/
+            label: SciPy
+          - url: https://pywavelets.readthedocs.io/
+            label: PyWavelets
+          - url: https://python-control.org/
+            label: python-control
+          - url: https://hyperspy.org/
+            label: HiperSpy
+      - title: Processamento de imagens
         alttext: Uma fotografia das montanhas.
+        links:
+          - url: https://scikit-image.org/
+            label: Scikit-image
+          - url: https://opencv.org/
+            label: OpenCV
+          - url: https://mahotas.rtfd.io/
+            label: Mahotas
         img: /images/content_images/sc_dom_img/image_processing.svg
-      - 
-        title: Gráficos e Redes
+      - title: Gráficos e Redes
         alttext: Um grafo simples.
         img: /images/content_images/sc_dom_img/sd6.svg
-      - 
-        title: Processos de Astronomia
+        links:
+          - url: https://networkx.org/
+            label: NetworkX
+          - url: https://graph-tool.skewed.de/
+            label: graph-tool
+          - url: https://igraph.org/python/
+            label: igraph
+          - url: https://pygsp.rtfd.io/
+            label: PyGSP
+      - title: Processos de Astronomia
         alttext: Um telescópio.
         img: /images/content_images/sc_dom_img/astronomy_processes.svg
-      - 
-        title: Psicologia Cognitiva
+        links:
+          - url: https://www.astropy.org/
+            label: AstroPy
+          - url: https://sunpy.org/
+            label: SunPy
+          - url: https://spacepy.github.io/
+            label: SpacePy
+      - title: Psicologia Cognitiva
         alttext: Uma cabeça humana com engrenagens.
         img: /images/content_images/sc_dom_img/cognitive_psychology.svg
-    librariesrow2:
-      - 
-        title: Bioinformática
+        links:
+          - url: https://www.psychopy.org/
+            label: PsychoPy
+      - title: Bioinformática
         alttext: Um pedaço de DNA.
         img: /images/content_images/sc_dom_img/bioinformatics.svg
-      - 
-        title: Inferência Bayesiana
+        links:
+          - url: https://biopython.org/
+            label: BioPython
+          - url: http://scikit-bio.org/
+            label: Scikit-Bio
+          - url: https://github.com/openvax/pyensembl
+            label: PyEnsembl
+          - url: http://etetoolkit.org/
+            label: ETE
+      - title: Inferência Bayesiana
         alttext: Um gráfico com uma curva em forma de sino.
         img: /images/content_images/sc_dom_img/bayesian_inference.svg
-      - 
-        title: Análise Matemática
+        links:
+          - url: https://pystan.readthedocs.io/en/latest/
+            label: PyStan
+          - url: https://docs.pymc.io/
+            label: PyMC3
+          - url: https://arviz-devs.github.io/arviz/
+            label: ArviZ
+          - url: https://emcee.readthedocs.io/
+            label: emcee
+      - title: Análise Matemática
         alttext: Quatro símbolos matemáticos.
         img: /images/content_images/sc_dom_img/mathematical_analysis.svg
-      - 
-        title: Química
+        links:
+          - url: https://www.scipy.org/
+            label: SciPy
+          - url: https://www.sympy.org/
+            label: SymPy
+          - url: https://www.cvxpy.org/
+            label: cvxpy
+          - url: https://fenicsproject.org/
+            label: FEniCS
+      - title: Química
         alttext: Um tubo de ensaio.
         img: /images/content_images/sc_dom_img/chemistry.svg
-      - 
-        title: Geociências
+        links:
+          - url: https://cantera.org/
+            label: Cantera
+          - url: https://www.mdanalysis.org/
+            label: MDAnalysis
+          - url: https://github.com/rdkit/rdkit
+            label: RDKit
+          - url: https://www.pybamm.org/
+            label: PyBaMM
+      - title: Geociências
         alttext: A Terra.
         img: /images/content_images/sc_dom_img/geoscience.svg
-      - 
-        title: Processamento Geográfico
+        links:
+          - url: https://pangeo.io/
+            label: Pangeo
+          - url: https://simpeg.xyz/
+            label: Simpeg
+          - url: https://github.com/obspy/obspy/wiki
+            label: ObsPy
+          - url: https://www.fatiando.org/
+            label: Fatiando a Terra
+      - title: Processamento Geográfico
         alttext: Um mapa.
         img: /images/content_images/sc_dom_img/GIS.svg
-      - 
-        title: Arquitetura e Engenharia
+        links:
+          - url: https://shapely.readthedocs.io/
+            label: Shapely
+          - url: https://geopandas.org/
+            label: GeoPandas
+          - url: https://python-visualization.github.io/folium
+            label: Folium
+      - title: Arquitetura e Engenharia
         alttext: Uma placa de desenvolvimento de microprocessador.
         img: /images/content_images/sc_dom_img/robotics.svg
+        links:
+          - url: https://compas.dev/
+            label: COMPAS
+          - url: https://cityenergyanalyst.com/
+            label: City Energy Analyst - Analista de Energía de Ciudad
+          - url: https://nortikin.github.io/sverchok/
+            label: Sverchok
   datascience:
     intro: "NumPy está no centro de um rico ecossistema de bibliotecas de ciência de dados. Um fluxo de trabalho típico de ciência de dados exploratório pode parecer assim:"
     image1:
-      - 
-        img: /images/content_images/ds-landscape.png
+      - img: /images/content_images/ds-landscape.png
         alttext: Diagrama de bibliotecas Python. As cinco categorias são 'Extrair, Transformar, Carregar', 'Exploração de Dados', 'Modelo de Dados', 'Avaliação de Dados' e 'Apresentação de Dados'.
     image2:
-      - 
-        img: /images/content_images/data-science.png
+      - img: /images/content_images/data-science.png
         alttext: Diagram of three overlapping circle. The circles labeled 'Mathematics', 'Computer Science' and 'Domain Expertise'. In the middle of the diagram, which has the three circles overlapping it, is an area labeled 'Data Science'.
     examples:
-      - 
-        text: "<b>Extract, Transform, Load: </b>[Pandas](https://pandas.pydata.org),[ Intake](https://intake.readthedocs.io),[PyJanitor](https://pyjanitor-devs.github.io/pyjanitor/)"
-      - 
-        text: "<b>Exploratory analysis: </b>[Jupyter](https://jupyter.org),[Seaborn](https://seaborn.pydata.org),[ Matplotlib](https://matplotlib.org),[ Altair](https://altair-viz.github.io)"
-      - 
-        text: "<b>Model and evaluate: </b>[scikit-learn](https://scikit-learn.org),[ statsmodels](https://www.statsmodels.org/stable/index.html),[ PyMC3](https://docs.pymc.io),[ spaCy](https://spacy.io)"
-      - 
-        text: "<b>Report in a dashboard: </b>[Dash](https://plotly.com/dash),[ Panel](https://panel.holoviz.org),[ Voila](https://github.com/voila-dashboards/voila)"
+      - text: "<b>Extract, Transform, Load: </b>[Pandas](https://pandas.pydata.org),[ Intake](https://intake.readthedocs.io),[PyJanitor](https://pyjanitor-devs.github.io/pyjanitor/)"
+      - text: "<b>Exploratory analysis: </b>[Jupyter](https://jupyter.org),[Seaborn](https://seaborn.pydata.org),[ Matplotlib](https://matplotlib.org),[ Altair](https://altair-viz.github.io)"
+      - text: "<b>Model and evaluate: </b>[scikit-learn](https://scikit-learn.org),[ statsmodels](https://www.statsmodels.org/stable/index.html),[ PyMC3](https://docs.pymc.io),[ spaCy](https://spacy.io)"
+      - text: "<b>Report in a dashboard: </b>[Dash](https://plotly.com/dash),[ Panel](https://panel.holoviz.org),[ Voila](https://github.com/voila-dashboards/voila)"
     content:
-      - 
-        text: For high data volumes, [Dask](https://dask.org) and[Ray](https://ray.io/) are designed to scale. Stabledeployments rely on data versioning ([DVC](https://dvc.org)),experiment tracking ([MLFlow](https://mlflow.org)), andworkflow automation ([Airflow](https://airflow.apache.org) and[Prefect](https://www.prefect.io)).
+      - text: For high data volumes, [Dask](https://dask.org) and[Ray](https://ray.io/) are designed to scale. Stabledeployments rely on data versioning ([DVC](https://dvc.org)),experiment tracking ([MLFlow](https://mlflow.org)), andworkflow automation ([Airflow](https://airflow.apache.org) and[Prefect](https://www.prefect.io)).
   visualization:
     images:
-      - 
-        url: https://www.fusioncharts.com/blog/best-python-data-visualization-libraries
+      - url: https://www.fusioncharts.com/blog/best-python-data-visualization-libraries
         img: /images/content_images/v_matplotlib.png
         alttext: Um streamplot feito em matplotlib
-      - 
-        url: https://github.com/yhat/ggpy
+      - url: https://github.com/yhat/ggpy
         img: /images/content_images/v_ggpy.png
         alttext: Um gráfico scatter-plot feito em ggpy
-      - 
-        url: https://www.journaldev.com/19692/python-plotly-tutorial
+      - url: https://www.journaldev.com/19692/python-plotly-tutorial
         img: /images/content_images/v_plotly.png
         alttext: Um box-plot feito no plotly
-      - 
-        url: https://altair-viz.github.io/gallery/streamgraph.html
+      - url: https://altair-viz.github.io/gallery/streamgraph.html
         img: /images/content_images/v_altair.png
         alttext: Um gráfico streamgraph feito em altair
-      - 
-        url: https://seaborn.pydata.org
+      - url: https://seaborn.pydata.org
         img: /images/content_images/v_seaborn.png
         alttext: A plot duplo com dois tipos de gráficos, um plot-graph e um gráfico de frequência feitos no seaborn
-      - 
-        url: https://docs.pyvista.org/
+      - url: https://docs.pyvista.org/
         img: /images/content_images/v_pyvista.png
         alttext: Uma renderização de volume 3D feita no PyVista.
-      - 
-        url: https://napari.org
+      - url: https://napari.org
         img: /images/content_images/v_napari.png
         alttext: Uma imagem multidimensional, feita em napari.
-      - 
-        url: https://vispy.org/gallery/index.html
+      - url: https://vispy.org/gallery/index.html
         img: /images/content_images/v_vispy.png
         alttext: Diagrama de Voronoi feito com vispy.
     content:
-      - 
-        text: NumPy é um componente essencial no crescente [campo de visualização em Python](https://pyviz.org/overviews/index.html), que inclui [Matplotlib](https://matplotlib.org), [Seaborn](https://seaborn.pydata.org), [Plotly](https://plot.ly), [Altair](https://altair-viz.github.io), [Bokeh](https://docs.bokeh.org/en/latest/), [Holoviz](https://holoviz.org), [Vispy](http://vispy.org), [Napari](https://github.com/napari/napari), e [PyVista](https://github.com/pyvista/pyvista), para citar alguns.
-      - 
-        text: O processamento de grandes arrays acelerado pela NumPy permite que os pesquisadores visualizem conjuntos de dados muito maiores do que o Python nativo poderia permitir.
+      - text: NumPy é um componente essencial no crescente [campo de visualização em Python](https://pyviz.org/overviews/index.html), que inclui [Matplotlib](https://matplotlib.org), [Seaborn](https://seaborn.pydata.org), [Plotly](https://plot.ly), [Altair](https://altair-viz.github.io), [Bokeh](https://docs.bokeh.org/en/latest/), [Holoviz](https://holoviz.org), [Vispy](http://vispy.org), [Napari](https://github.com/napari/napari), e [PyVista](https://github.com/pyvista/pyvista), para citar alguns.
+      - text: O processamento de grandes arrays acelerado pela NumPy permite que os pesquisadores visualizem conjuntos de dados muito maiores do que o Python nativo poderia permitir.


### PR DESCRIPTION
#### Brief description of what is fixed or changed

This restores the display of the Scientific Domains tab for Japanese and Portuguese. An update of how these tabs are pulled together was not applied to the translated pages which was causing the missing content.

Also updates the CSS for the tabs so that the scientific domain titles are correctly aligned.

Finally, there were some newlines applies to yaml files that are probably incorrect. 