### PR TITLE
Updated two URLs in deeplabcut-dnn.md

### DIFF
--- a/content/en/case-studies/deeplabcut-dnn.md
+++ b/content/en/case-studies/deeplabcut-dnn.md
@@ -39,7 +39,7 @@ DeepLabCut allows researchers to estimate the pose of the subject, efficiently e
 
 DeepLabCut uses a principle called [transfer learning](https://arxiv.org/pdf/1909.11229), which greatly reduces the amount of training data required and speeds up the convergence of the training period.  Depending on the needs, users can pick different network architectures that provide faster inference (e.g. MobileNetV2), which can also be combined with real-time experimental feedback. DeepLabCut originally used the feature detectors from a top-performing human pose estimation architecture, called [DeeperCut](https://arxiv.org/abs/1605.03170), which inspired the name. The package now has been significantly changed to include additional architectures, augmentation methods, and a full front-end user experience. Furthermore, to support large-scale biological experiments DeepLabCut provides active learning capabilities so that users can increase the training set over time to cover edge cases and make their pose estimation algorithm robust within the specific context.
 
-Recently, the [DeepLabCut model zoo](http://www.mousemotorlab.org/dlc-modelzoo) was introduced, which provides pre-trained models for various species and experimental conditions from facial analysis in primates to dog posture. This can be run for instance in the cloud without any labeling of new data, or neural network training, and no programming experience is necessary.
+Recently, the [DeepLabCut model zoo](https://deeplabcut.github.io/DeepLabCut/docs/ModelZoo.html) was introduced, which provides pre-trained models for various species and experimental conditions from facial analysis in primates to dog posture. This can be run for instance in the cloud without any labeling of new data, or neural network training, and no programming experience is necessary.
 
 ### Key Goals and Results
 
@@ -167,7 +167,7 @@ attributionlink = 'https://www.researchgate.net/figure/DeepLabCut-work-flow-The-
 
 Observing and efficiently describing behavior is a core tenant of modern
 ethology, neuroscience, medicine, and technology.
-[DeepLabCut](http://orga.cvss.cc/wp-content/uploads/2019/05/NathMathis2019.pdf)
+[DeepLabCut](https://static1.squarespace.com/static/57f6d51c9f74566f55ecf271/t/5eab5ff7999bf94756b27481/1588289532243/NathMathis2019.pdf)
 allows researchers to estimate the pose of the subject, efficiently enabling
 them to quantify the behavior. With only a small set of training images,
 the DeepLabCut Python toolbox allows training a neural network to within human


### PR DESCRIPTION

#### Brief description of what is fixed or changed

Updated two URLs in deeplabcut-dnn.md.

1. DeepLabCut model zoo
New link: https://deeplabcut.github.io/DeepLabCut/docs/ModelZoo.html
Old link does not work: http://www.mousemotorlab.org/dlc-modelzoo

2. DeepLabCut paper in Summary section
New link: https://static1.squarespace.com/static/57f6d51c9f74566f55ecf271/t/5eab5ff7999bf94756b27481/1588289532243/NathMathis2019.pdf
Old link does not work: http://orga.cvss.cc/wp-content/uploads/2019/05/NathMathis2019.pdf

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

