### PR TITLE
Updated links to SciPy Latin America and SciPy Japan

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -60,9 +60,9 @@ The NumPy project doesn't organize its own conferences. The conferences that hav
 
 - [SciPy US](https://conference.scipy.org)
 - [EuroSciPy](https://www.euroscipy.org)
-- [SciPy Latin America](https://www.scipyla.org)
+- [SciPy Latin America](https://pythoncientifico.ar/)
 - [SciPy India](https://scipy.in)
-- [SciPy Japan](https://conference.scipy.org)
+- [SciPy Japan](https://www.scipyjapan.scipy.org/)
 - [PyData conferences](https://pydata.org/event-schedule/) (15-20 events a year spread over many countries)
 
 Many of these conferences include tutorial days that cover NumPy and/or sprints where you can learn how to contribute to NumPy or related open source projects.


### PR DESCRIPTION

#### Brief description of what is fixed or changed

Updated links to SciPy Latin America and SciPy Japan

The correct links are:
SciPy Latin America: https://pythoncientifico.ar/
SciPy Japan: https://www.scipyjapan.scipy.org/

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

