### PR TITLE
fix two URLs

### DIFF
--- a/content/en/case-studies/blackhole-image.md
+++ b/content/en/case-studies/blackhole-image.md
@@ -114,7 +114,7 @@ title = 'Software dependency chart of ehtim package highlighting NumPy'
 [ehtim]: https://github.com/achael/eht-imaging
 
 Besides NumPy, many other packages, such as
-[SciPy](https://www.scipy.org) and [Pandas](https://pandas.io), are part of the
+[SciPy](https://scipy.org) and [Pandas](https://pandas.pydata.org), are part of the
 data processing pipeline for imaging the black hole.
 The standard astronomical file formats and time/coordinate transformations
 were handled by [Astropy][astropy], while [Matplotlib][mpl] was used

--- a/content/es/case-studies/blackhole-image.md
+++ b/content/es/case-studies/blackhole-image.md
@@ -73,7 +73,7 @@ alt = 'mapa de dependencias de ehtim resaltando a numpy'
 title = 'Gráfico de dependencias de software del paquete ehtim resaltando a NumPy'
 {{< /figure >}}
 
-Además de NumPy, muchos otros paquetes, como [SciPy](https://www.scipy.org) y [Pandas](https://pandas.io), son parte del flujo de procesamiento de datos para fotografiar el agujero negro. Los formatos estándar de archivos astronómicos y transformaciones de tiempo/coordenadas fueron manejados por [Astropy][astropy], mientras que [Matplotlib][mpl] fue utilizado en la visualización de datos a través del flujo de análisis, incluyendo la generación de la imagen final del agujero negro.
+Además de NumPy, muchos otros paquetes, como [SciPy](https://scipy.org) y [Pandas](https://pandas.pydata.org), son parte del flujo de procesamiento de datos para fotografiar el agujero negro. Los formatos estándar de archivos astronómicos y transformaciones de tiempo/coordenadas fueron manejados por [Astropy][astropy], mientras que [Matplotlib][mpl] fue utilizado en la visualización de datos a través del flujo de análisis, incluyendo la generación de la imagen final del agujero negro.
 
 ## Resumen
 

--- a/content/ja/case-studies/blackhole-image.md
+++ b/content/ja/case-studies/blackhole-image.md
@@ -75,7 +75,7 @@ alt = 'ehtim dependency map highlighting numpy'
 title = 'NumPyの中心としたehtimのソフトウェア依存図'
 {{< /figure >}}
 
-NumPyだけでなく、[SciPy](https://www.scipy.org)や[Pandas](https://pandas.io)などのパッケージもブラックホール画像化におけるデータ処理パイプラインに利用されています。 天文学の標準的なファイル形式や時間/座標変換 は[Astropy][astropy]で実装され、ブラックホールの最終画像の生成を含め、解析パイプライン全体でのデータ可視化には [Matplotlib][mpl]が利用されました。
+NumPyだけでなく、[SciPy](https://scipy.org)や[Pandas](https://pandas.pydata.org)などのパッケージもブラックホール画像化におけるデータ処理パイプラインに利用されています。 天文学の標準的なファイル形式や時間/座標変換 は[Astropy][astropy]で実装され、ブラックホールの最終画像の生成を含め、解析パイプライン全体でのデータ可視化には [Matplotlib][mpl]が利用されました。
 
 ## まとめ
 

--- a/content/pt/case-studies/blackhole-image.md
+++ b/content/pt/case-studies/blackhole-image.md
@@ -75,7 +75,7 @@ alt = 'ehtim dependency map highlighting numpy'
 title = 'Diagrama de dependência de software do pacote ehtim evidenciando o NumPy'
 {{< /figure >}}
 
-Além do NumPy, muitos outros pacotes como [SciPy](https://www.scipy.org) e [Pandas](https://pandas.io) foram usados na *pipeline* de processamento de dados para criar a imagem do buraco negro. Os arquivos astronômicos de formato padrão e transformações de tempo/coordenadas foram tratados pelo [Astropy][astropy] enquanto a [Matplotlib][mpl] foi usada na visualização de dados em todas as etapas de análise, incluindo a geração da imagem final do buraco negro.
+Além do NumPy, muitos outros pacotes como [SciPy](https://scipy.org) e [Pandas](https://pandas.pydata.org) foram usados na *pipeline* de processamento de dados para criar a imagem do buraco negro. Os arquivos astronômicos de formato padrão e transformações de tempo/coordenadas foram tratados pelo [Astropy][astropy] enquanto a [Matplotlib][mpl] foi usada na visualização de dados em todas as etapas de análise, incluindo a geração da imagem final do buraco negro.
 
 ## Resumo
 


### PR DESCRIPTION
fix two URLs:

1. https://www.scipy.org -> https://scipy.org
this is just a redirect

2. https://pandas.io -> https://pandas.pydata.org
the second URL links to a spam website that has nothing to do with pandas Python package