### PR TITLE
DOC: Update the link to Guide to NumPy (2015)

### DIFF
--- a/content/en/learn.md
+++ b/content/en/learn.md
@@ -26,7 +26,7 @@ There's a ton of information about NumPy out there. If you are just starting, we
 
 <i class="fas fa-book"></i> **Books**
 
-* [Guide to NumPy *by Travis E. Oliphant*](https://web.mit.edu/dvp/Public/numpybook.pdf) This is a free version 1 from 2006. For the latest copy (2015) see [here](https://www.barnesandnoble.com/w/guide-to-numpy-travis-e-oliphant-phd/1144670472).
+* [Guide to NumPy *by Travis E. Oliphant*](https://web.mit.edu/dvp/Public/numpybook.pdf) This is a free version 1 from 2006. For the latest copy (2015) see [here](https://dl.acm.org/doi/10.5555/2886196).
 * [From Python to NumPy *by Nicolas P. Rougier*](https://www.labri.fr/perso/nrougier/from-python-to-numpy/)
 * [Elegant SciPy](https://www.amazon.com/Elegant-SciPy-Art-Scientific-Python/dp/1491922877) *by Juan Nunez-Iglesias, Stefan van der Walt, and Harriet Dashnow*
 


### PR DESCRIPTION

#### Brief description of what is fixed or changed

Update the link to Guide to NumPy (2015).
https://dl.acm.org/doi/10.5555/2886196

The old link does not work:
https://www.barnesandnoble.com/w/guide-to-numpy-travis-e-oliphant-phd/1144670472

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

