### PR TITLE
rename PyMC3 to PyMC

### DIFF
--- a/content/en/tabcontents.yaml
+++ b/content/en/tabcontents.yaml
@@ -173,7 +173,7 @@ params:
         - url: https://pystan.readthedocs.io/en/latest/
           label: PyStan
         - url: https://docs.pymc.io/
-          label: PyMC3
+          label: PyMC
         - url: https://arviz-devs.github.io/arviz/
           label: ArviZ
         - url: https://emcee.readthedocs.io/
@@ -250,7 +250,7 @@ params:
     examples:
     - text: "<b>Extract, Transform, Load: </b>[Pandas](https://pandas.pydata.org), [Intake](https://intake.readthedocs.io), [PyJanitor](https://pyjanitor-devs.github.io/pyjanitor/)"
     - text: "<b>Exploratory analysis: </b>[Jupyter](https://jupyter.org), [Seaborn](https://seaborn.pydata.org), [Matplotlib](https://matplotlib.org), [Altair](https://altair-viz.github.io)"
-    - text: "<b>Model and evaluate: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC3](https://docs.pymc.io), [spaCy](https://spacy.io)"
+    - text: "<b>Model and evaluate: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC](https://docs.pymc.io), [spaCy](https://spacy.io)"
     - text: "<b>Report in a dashboard: </b>[Dash](https://plotly.com/dash), [Panel](https://panel.holoviz.org), [Voila](https://voila.readthedocs.io/)"
 
     content:

--- a/content/es/tabcontents.yaml
+++ b/content/es/tabcontents.yaml
@@ -168,7 +168,7 @@ params:
           - url: https://pystan.readthedocs.io/en/latest/
             label: PyStan
           - url: https://docs.pymc.io/
-            label: PyMC3
+            label: PyMC
           - url: https://arviz-devs.github.io/arviz/
             label: ArviZ
           - url: https://emcee.readthedocs.io/
@@ -240,7 +240,7 @@ params:
     examples:
       - text: "<b>Extraer, Transformar, Cargar: </b>[Pandas](https://pandas.pydata.org), [Intake](https://intake.readthedocs.io), [PyJanitor](https://pyjanitor.readthedocs.io/)"
       - text: "<b>Análisis Exploratorio: </b>[Jupyter](https://jupyter.org), [Seaborn](https://seaborn.pydata.org), [Matplotlib](https://matplotlib.org), [Altair](https://altair-viz.github.io)"
-      - text: "<b>Modelado y evaluación: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC3](https://docs.pymc.io), [spaCy](https://spacy.io)"
+      - text: "<b>Modelado y evaluación: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC](https://docs.pymc.io), [spaCy](https://spacy.io)"
       - text: "<b>Informes en un panel de control: </b>[Dash](https://plotly.com/dash), [Panel](https://panel.holoviz.org), [Voila](https://github.com/voila-dashboards/voila)"
     content:
       - text: Para grandes volúmenes de datos, [Dask](https://dask.org) y [Ray](https://ray.io/) están diseñados para escalarse. Las implementaciones estables se basan en el versionado de datos ([DVC](https://dvc.org)), rastreo de experimentos ([MLFlow](https://mlflow.org)), y automatización del flujo de trabajo ([Airflow](https://airflow.apache.org), [Dagster](https://dagster.io) y [Prefect](https://www.prefect.io)).

--- a/content/ja/tabcontents.yaml
+++ b/content/ja/tabcontents.yaml
@@ -224,7 +224,7 @@ params:
             label: PyStan
           - 
             url: https://docs.pymc.io/
-            label: PyMC3
+            label: PyMC
           - 
             url: https://arviz-devs.github.io/arviz/
             label: ArviZ
@@ -326,7 +326,7 @@ params:
       - 
         text: "<b>探索的解析: </b>[Jupyter](https://jupyter.org), [Seaborn](https://seaborn.pydata.org), [Matplotlib](https://matplotlib.org), [Altair](https://altair-viz.github.io)"
       - 
-        text: "<b>モデリングと評価: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC3](https://docs.pymc.io), [spaCy](https://spacy.io)"
+        text: "<b>モデリングと評価: </b>[scikit-learn](https://scikit-learn.org), [statsmodels](https://www.statsmodels.org/stable/index.html), [PyMC](https://docs.pymc.io), [spaCy](https://spacy.io)"
       - 
         text: "<b>ダッシュボードでのレポート: </b>[Dash](https://plotly.com/dash), [Panel](https://panel.holoviz.org), [Voila](https://github.com/voila-dashboards/voila)"
     content:

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -173,7 +173,7 @@ params:
           - url: https://pystan.readthedocs.io/en/latest/
             label: PyStan
           - url: https://docs.pymc.io/
-            label: PyMC3
+            label: PyMC
           - url: https://arviz-devs.github.io/arviz/
             label: ArviZ
           - url: https://emcee.readthedocs.io/
@@ -245,7 +245,7 @@ params:
     examples:
       - text: "<b>Extract, Transform, Load: </b>[Pandas](https://pandas.pydata.org),[ Intake](https://intake.readthedocs.io),[PyJanitor](https://pyjanitor-devs.github.io/pyjanitor/)"
       - text: "<b>Exploratory analysis: </b>[Jupyter](https://jupyter.org),[Seaborn](https://seaborn.pydata.org),[ Matplotlib](https://matplotlib.org),[ Altair](https://altair-viz.github.io)"
-      - text: "<b>Model and evaluate: </b>[scikit-learn](https://scikit-learn.org),[ statsmodels](https://www.statsmodels.org/stable/index.html),[ PyMC3](https://docs.pymc.io),[ spaCy](https://spacy.io)"
+      - text: "<b>Model and evaluate: </b>[scikit-learn](https://scikit-learn.org),[ statsmodels](https://www.statsmodels.org/stable/index.html),[ PyMC](https://docs.pymc.io),[ spaCy](https://spacy.io)"
       - text: "<b>Report in a dashboard: </b>[Dash](https://plotly.com/dash),[ Panel](https://panel.holoviz.org),[ Voila](https://github.com/voila-dashboards/voila)"
     content:
       - text: For high data volumes, [Dask](https://dask.org) and[Ray](https://ray.io/) are designed to scale. Stabledeployments rely on data versioning ([DVC](https://dvc.org)),experiment tracking ([MLFlow](https://mlflow.org)), andworkflow automation ([Airflow](https://airflow.apache.org) and[Prefect](https://www.prefect.io)).


### PR DESCRIPTION
project PyMC3 has been renamed to PyMC, update the website to reflect it.

See https://en.wikipedia.org/wiki/PyMC and https://www.pymc.io