### PR TITLE
Update Steering Council and Institutional Partners membership

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -15,23 +15,24 @@ The NumPy Steering Council is the project's governing body. Its role is to ensur
 - Sebastian Berg
 - Ralf Gommers
 - Charles Harris
-- Stephan Hoyer
 - Inessa Pawson
 - Matti Picus
 - Stéfan van der Walt
 - Melissa Weber Mendonça
-- Eric Wieser
+- Marten van Kerkwijk
+- Nathan Goldbaum
 
 Emeritus:
 
 - Alex Griffing (2015-2017)
 - Allan Haldane (2015-2021)
-- Marten van Kerkwijk (2017-2019)
 - Travis Oliphant (project founder, 2005-2012)
 - Nathaniel Smith (2012-2021)
 - Julian Taylor (2013-2021)
 - Jaime Fernández del Río (2014-2021)
 - Pauli Virtanen (2008-2021)
+- Eric Wieser (2017-2025)
+- Stephan Hoyer (2017-2025)
 
 To contact the NumPy Steering Council, please email numpy-team@googlegroups.com.
 
@@ -71,7 +72,7 @@ NumPy receives direct funding from the following sources:
 Institutional Partners are organizations that support the project by employing people that contribute to NumPy as part of their job. Current Institutional Partners include:
 
 - UC Berkeley (Stéfan van der Walt)
-- Quansight (Nathan Goldbaum, Ralf Gommers, Matti Picus, Melissa Weber Mendonça)
+- Quansight (Nathan Goldbaum, Ralf Gommers, Matti Picus, Melissa Weber Mendonça, Mateusz Sokol, Rohit Goswami)
 - NVIDIA (Sebastian Berg)
 
 {{< partners >}}


### PR DESCRIPTION
Cc'ing the folks whose name is touched here for visibility: @ngoldbaum, @mhvk, @shoyer, @eric-wieser, @mtsokol, @HaoZeke. 

Welcome back to the steering council Marten, and welcome to the steering council Nathan! And a big thank you to Stephan and Eric for your contributions to NumPy's governance!