### PR TITLE
fix a URL redirect www.scipy.org -> scipy.org

### DIFF
--- a/content/en/tabcontents.yaml
+++ b/content/en/tabcontents.yaml
@@ -1,7 +1,7 @@
 params:
   machinelearning:
     paras:
-    - para1: NumPy forms the basis of powerful machine learning libraries like [scikit-learn](https://scikit-learn.org) and [SciPy](https://www.scipy.org). As machine learning grows, so does the list of libraries built on NumPy. [TensorFlow’s](https://www.tensorflow.org) deep learning capabilities have broad applications &mdash; among them speech and image recognition, text-based applications, time-series analysis, and video detection. [PyTorch](https://pytorch.org), another deep learning library, is popular among researchers in computer vision and natural language processing.
+    - para1: NumPy forms the basis of powerful machine learning libraries like [scikit-learn](https://scikit-learn.org) and [SciPy](https://scipy.org). As machine learning grows, so does the list of libraries built on NumPy. [TensorFlow’s](https://www.tensorflow.org) deep learning capabilities have broad applications &mdash; among them speech and image recognition, text-based applications, time-series analysis, and video detection. [PyTorch](https://pytorch.org), another deep learning library, is popular among researchers in computer vision and natural language processing.
       para2: Statistical techniques called [ensemble methods](https://scikit-learn.org/stable/modules/ensemble.html) such as binning, bagging, stacking, and boosting are among the ML algorithms implemented by tools such as [XGBoost](https://xgboost.readthedocs.io/), [LightGBM](https://lightgbm.readthedocs.io/en/latest/), and [CatBoost](https://catboost.ai) &mdash; one of the fastest inference engines. [Yellowbrick](https://www.scikit-yb.org/en/latest/) and [Eli5](https://eli5.readthedocs.io/en/latest/) offer machine learning visualizations.
 
   arraylibraries:
@@ -108,7 +108,7 @@ params:
       alttext: A bar chart with positive and negative values.
       img: /images/content_images/sc_dom_img/signal_processing.svg
       links:
-        - url: https://www.scipy.org/
+        - url: https://scipy.org
           label: SciPy
         - url: https://pywavelets.readthedocs.io/
           label: PyWavelets
@@ -182,7 +182,7 @@ params:
       alttext: Four mathematical symbols.
       img: /images/content_images/sc_dom_img/mathematical_analysis.svg
       links:
-        - url: https://www.scipy.org/
+        - url: https://scipy.org
           label: SciPy
         - url: https://www.sympy.org/
           label: SymPy

--- a/content/es/tabcontents.yaml
+++ b/content/es/tabcontents.yaml
@@ -1,7 +1,7 @@
 params:
   machinelearning:
     paras:
-      - para1: NumPy constituye la base de potentes librerías de aprendizaje automático como [scikit-learn](https://scikit-learn.org) y [SciPy](https://www.scipy.org). A medida que crece el aprendizaje automático, también lo hace la lista de librerías basadas en NumPy. Las capacidades de aprendizaje profundo de [TensorFlow](https://www.tensorflow.org) tienen amplias aplicaciones&mdash; entre ellas el reconocimiento de voz e imágenes, las aplicaciones basadas en texto, el análisis de series de tiempo y la detección de vídeo. [PyTorch](https://pytorch.org), otra librería de aprendizaje profundo, es popular entre los investigadores de visión artificial y procesamiento del lenguaje natural.
+      - para1: NumPy constituye la base de potentes librerías de aprendizaje automático como [scikit-learn](https://scikit-learn.org) y [SciPy](https://scipy.org). A medida que crece el aprendizaje automático, también lo hace la lista de librerías basadas en NumPy. Las capacidades de aprendizaje profundo de [TensorFlow](https://www.tensorflow.org) tienen amplias aplicaciones&mdash; entre ellas el reconocimiento de voz e imágenes, las aplicaciones basadas en texto, el análisis de series de tiempo y la detección de vídeo. [PyTorch](https://pytorch.org), otra librería de aprendizaje profundo, es popular entre los investigadores de visión artificial y procesamiento del lenguaje natural.
         para2: Las técnicas estadísticas denominadas [métodos ensemble](https://scikit-learn.org/stable/modules/ensemble.html), como binning, bagging, stacking y boosting, se encuentran entre los algoritmos de ML implementados por herramientas como [XGBoost](https://xgboost.readthedocs.io/), [LightGBM](https://lightgbm.readthedocs.io/en/latest/) y [CatBoost](https://catboost.ai) &mdash; uno de los motores de inferencia más rápidos. [Yellowbrick](https://www.scikit-yb.org/en/latest/) y [Eli5](https://eli5.readthedocs.io/en/latest/) ofrecen visualizaciones de aprendizaje automático.
   arraylibraries:
     intro:
@@ -103,7 +103,7 @@ params:
         alttext: Un gráfico de barras con valores positivos y negativos.
         img: /images/content_images/sc_dom_img/signal_processing.svg
         links:
-          - url: https://www.scipy.org/
+          - url: https://scipy.org
             label: SciPy
           - url: https://pywavelets.readthedocs.io/
             label: PyWavelets
@@ -177,7 +177,7 @@ params:
         alttext: Cuatro símbolos matemáticos.
         img: /images/content_images/sc_dom_img/mathematical_analysis.svg
         links:
-          - url: https://www.scipy.org/
+          - url: https://scipy.org
             label: SciPy
           - url: https://www.sympy.org/
             label: SymPy

--- a/content/ja/tabcontents.yaml
+++ b/content/ja/tabcontents.yaml
@@ -2,7 +2,7 @@ params:
   machinelearning:
     paras:
       - 
-        para1: NumPyは、[scikit-learn](https://scikit-learn.org)や[SciPy](https://www.scipy.org)のような強力な機械学習ライブラリの基礎を形成しています。機械学習の技術分野が成長するにつれ、NumPyをベースにしたライブラリの数も増えています。[TensorFlow](https://www.tensorflow.org)の深層学習機能は、音声認識や画像認識、テキストベースのアプリケーション、時系列分析、動画検出など、幅広い応用用途があります。[PyTorch](https://pytorch.org)も、コンピュータビジョンや自然言語処理の研究者に人気のある深層学習ライブラリです。[MXNet](https://github.com/apache/incubator-mxnet)もAIパッケージの一つで、深層学習の設計図やテンプレート機能を提供しています。
+        para1: NumPyは、[scikit-learn](https://scikit-learn.org)や[SciPy](https://scipy.org)のような強力な機械学習ライブラリの基礎を形成しています。機械学習の技術分野が成長するにつれ、NumPyをベースにしたライブラリの数も増えています。[TensorFlow](https://www.tensorflow.org)の深層学習機能は、音声認識や画像認識、テキストベースのアプリケーション、時系列分析、動画検出など、幅広い応用用途があります。[PyTorch](https://pytorch.org)も、コンピュータビジョンや自然言語処理の研究者に人気のある深層学習ライブラリです。[MXNet](https://github.com/apache/incubator-mxnet)もAIパッケージの一つで、深層学習の設計図やテンプレート機能を提供しています。
         para2: '[ensemble](https://scikit-learn.org/stable/modules/ensemble.html)法と呼ばれる統計的手法であるビンニング、バギング、スタッキングや、[XGBoost](https://github.com/dmlc/xgboost)、[LightGBM](https://lightgbm.readthedocs.io/en/latest/)、[CatBoost](https://catboost.ai)などのツールで実装されているブースティングなどは、機械学習アルゴリズムの一つであり、最速の推論エンジンの一つです。[Yellowbrick](https://www.scikit-yb.org/en/latest/)や[Eli5](https://eli5.readthedocs.io/en/latest/)は機械学習の可視化機能を提供しています。'
   arraylibraries:
     intro:
@@ -133,7 +133,7 @@ params:
         img: /images/content_images/sc_dom_img/signal_processing.svg
         links:
           - 
-            url: https://www.scipy.org/
+            url: https://scipy.org
             label: SciPy
           - 
             url: https://pywavelets.readthedocs.io/
@@ -237,7 +237,7 @@ params:
         img: /images/content_images/sc_dom_img/mathematical_analysis.svg
         links:
           - 
-            url: https://www.scipy.org/
+            url: https://scipy.org
             label: SciPy
           - 
             url: https://www.sympy.org/

--- a/content/pt/tabcontents.yaml
+++ b/content/pt/tabcontents.yaml
@@ -1,7 +1,7 @@
 params:
   machinelearning:
     paras:
-      - para1: O NumPy forma a base de bibliotecas de aprendizagem de máquina poderosas como [scikit-learn](https://scikit-learn.org) e [SciPy](https://www.scipy.org). À medida que a disciplina de aprendizagem de máquina cresce, a lista de bibliotecas construidas a partir do NumPy também cresce. As funcionalidades de deep learning do [TensorFlow](https://www.tensorflow.org) tem diversas aplicações &mdash; entre elas, reconhecimento de imagem e de fala, aplicações baseadas em texto, análise de séries temporais, e detecção de vídeo. O [PyTorch](https://pytorch.org), outra biblioteca de deep learning, é popular entre pesquisadores em visão computacional e processamento de linguagem natural. O [MXNet](https://github.com/apache/incubator-mxnet) é outro pacote de IA, que fornece templates e protótipos para deep learning.
+      - para1: O NumPy forma a base de bibliotecas de aprendizagem de máquina poderosas como [scikit-learn](https://scikit-learn.org) e [SciPy](https://scipy.org). À medida que a disciplina de aprendizagem de máquina cresce, a lista de bibliotecas construidas a partir do NumPy também cresce. As funcionalidades de deep learning do [TensorFlow](https://www.tensorflow.org) tem diversas aplicações &mdash; entre elas, reconhecimento de imagem e de fala, aplicações baseadas em texto, análise de séries temporais, e detecção de vídeo. O [PyTorch](https://pytorch.org), outra biblioteca de deep learning, é popular entre pesquisadores em visão computacional e processamento de linguagem natural. O [MXNet](https://github.com/apache/incubator-mxnet) é outro pacote de IA, que fornece templates e protótipos para deep learning.
         para2: Técnicas estatísticas chamadas [métodos de ensemble](https://scikit-learn.org/stable/modules/ensemble.html) tais como binning, bagging, stacking, e boosting estão entre os algoritmos de ML implementados por ferramentas tais como [XGBoost](https://github.com/dmlc/xgboost), [LightGBM](https://lightgbm.readthedocs.io/en/latest/), e [CatBoost](https://catboost.ai) &mdash; um dos motores de inferência mais rápidos. [Yellowbrick](https://www.scikit-yb.org/en/latest/) e [Eli5](https://eli5.readthedocs.io/en/latest/) oferecem visualizações para aprendizagem de máquina.
   arraylibraries:
     intro:
@@ -108,7 +108,7 @@ params:
         alttext: Um gráfico de barras com valores positivos e negativos.
         img: /images/content_images/sc_dom_img/signal_processing.svg
         links:
-          - url: https://www.scipy.org/
+          - url: https://scipy.org
             label: SciPy
           - url: https://pywavelets.readthedocs.io/
             label: PyWavelets
@@ -182,7 +182,7 @@ params:
         alttext: Quatro símbolos matemáticos.
         img: /images/content_images/sc_dom_img/mathematical_analysis.svg
         links:
-          - url: https://www.scipy.org/
+          - url: https://scipy.org
             label: SciPy
           - url: https://www.sympy.org/
             label: SymPy


### PR DESCRIPTION
fix a URL redirect https://www.scipy.org -> https://scipy.org