### PR TITLE
Change prompt cell position for the NumPy REPL (do not merge)

### DIFF
--- a/layouts/partials/shell.html
+++ b/layouts/partials/shell.html
@@ -17,7 +17,7 @@
             <!-- Interactive Shell -->
             <iframe
                 class="numpy-shell"
-                src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&execute=0&code=import%20numpy%20as%20np"
+                src="https://jupyterlite.github.io/demo/repl/?toolbar=1&kernel=python&promptCellPosition=left&execute=0&code=import%20numpy%20as%20np"
             >
             </iframe>
         </div>


### PR DESCRIPTION
#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

This PR changes the prompt cell position for the NumPy REPL from the default (`bottom`) to `left`. This is, at the moment, not intended to be merged, as it is solely for trying out the new feature that was introduced the recent JupyterLite 0.6 release. Here is a visual diff:

Scenario | Before | After |
|--:|:----:|:----:|
| With the default `import numpy as np` snippet | ![numpy org_](https://github.com/user-attachments/assets/6d93cda9-f538-401a-875e-509e68f4d981) | ![numpy org_ (1)](https://github.com/user-attachments/assets/90685add-cdd8-4a8e-9c9b-7d9dccccc53b) |
| The example snippet is executed | ![numpy org_ (2)](https://github.com/user-attachments/assets/8edabc48-267c-42b8-80f6-afa1bf839deb) | ![numpy org_ (3)](https://github.com/user-attachments/assets/a290b015-767f-4fb8-a444-7f9e61ca9869) |

This might currently remain blocked until https://github.com/jupyterlab/jupyterlab/issues/17597 is resolved (I previously attempted to fix this in JupyterLite, but I was later prompted to the fact that the fix lies in JupyterLab instead). I would be on the fence here personally, as both of the layouts look fine to me. However, if the line length in a code snippet is long, say, >70 characters, some of them might get hidden until the layout is expanded manually.

A follow-up item could be to introduce a `width`/`ratio` element (for the `left` or the `right` positions) which could control the initial state of the prompt cell panel's and the output side panel's widths – it's currently split 50-50 between both but I could see a use case for a 40-60 or 30-70 split (or vice versa).

cc: @jtpio

Closes gh-869
