### PR TITLE
Fix improper comic shortcode that causes the NumPy navbar logo to be shrunk on the "Contribute" page(s)

### DIFF
--- a/layouts/shortcodes/comic.html
+++ b/layouts/shortcodes/comic.html
@@ -7,6 +7,5 @@
 <style>
     .comic img {
         max-width: 20%;
-        max-height: 20%;
     }
 </style>


### PR DESCRIPTION
#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->

The comic shortcode currently applies a style to all images it is utilised on, so the "Contribute" pages also inherit a `max-width: 20%` rule, which downsizes the NumPy logo in the navbar. Additionally, the div that applies the `comic` class to the comic cover image was being foreclosed without including the comic cover image within itself, breaking the secondary sidebar as the HTML became syntactically invalid (for context, the secondary sidebar is visible on other pages, such as the "Community" and "About Us" pages). This PR corrects these issues. See the table below for a comparison.

| Before | After |
|:------:|:------:|
| <img width="5088" height="3032" alt="image" src="https://github.com/user-attachments/assets/1b94ca5f-e5ae-47a5-b742-7de805a0739a" /> | <img width="5088" height="3032" alt="image" src="https://github.com/user-attachments/assets/e228569c-2a86-4597-b26a-ee1105ac44f6" /> | 

