### PR TITLE
Improve News page readability via section separation

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -2,3 +2,13 @@
 .navbar-logo-text {
   font-family: "Lato";
 }
+
+.content-container h3 {
+  border-top: 1px solid var(--pst-color-border);
+  padding-top: 1.25rem;
+  margin-top: 2rem;
+}
+.content-container h3:first-of-type {
+  border-top: none;
+  margin-top: 0;
+}


### PR DESCRIPTION

Fixes gh-890

This PR improves the readability of the News page by adding subtle visual separation between individual release sections. The change is CSS-only, scoped to the News page, and does not modify content, templates, or the theme.

