### PR TITLE
Update to SPHT v0.23 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:   ## show this help
 	@grep -h "##" $(MAKEFILE_LIST) | grep -v grep | sed -e 's/\(.*\):.*##\(.*\)/    \1: \2/'
 
 prepare:
-	git submodule update --init
+	git submodule update --init --recursive
 	python gen_config.py
 
 # All translations share the <team>.toml files in the en translation

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 # unless otherwise overridden by more specific contexts.
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.152.2"
+  HUGO_VERSION = "0.158.0"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 


### PR DESCRIPTION

#### Brief description of what is fixed or changed

<!-- If this pull request fixes an issue, write "Fixes gh-NNNN" in that exact
format, e.g. "Fixes gh-1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests . Please also
write a comment on that issue linking back to this pull request once it is
open.

OR/AND

Describe your changes here
-->


Hi! This PR updates the website to use the v0.23 release of the Scientific Python Hugo Theme, which we've released today: https://github.com/scientific-python/scientific-python-hugo-theme/releases/tag/v0.23.
